### PR TITLE
Update/add rust contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,8 +263,6 @@ dependencies = [
  "bs58",
  "hmac",
  "k256",
- "once_cell",
- "pbkdf2 0.12.2",
  "rand_core 0.6.4",
  "ripemd",
  "sha2 0.10.8",
@@ -472,34 +470,34 @@ dependencies = [
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9d2043a9e617b0d602fbc0a0ecd621568edbf3a9774890a6d562389bd8e1c"
+checksum = "32560304ab4c365791fd307282f76637213d8083c1a98490c35159cd67852237"
 dependencies = [
- "prost 0.11.9",
- "prost-types",
- "tendermint-proto",
- "tonic",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
+ "tendermint-proto 0.34.0",
+ "tonic 0.10.2",
 ]
 
 [[package]]
 name = "cosmrs"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af13955d6f356272e6def9ff5e2450a7650df536d8934f47052a20c76513d2f6"
+checksum = "47126f5364df9387b9d8559dcef62e99010e1d4098f39eb3f7ee4b5c254e40ea"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",
  "ecdsa",
  "eyre",
- "getrandom",
  "k256",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
+ "signature",
  "subtle-encoding",
- "tendermint",
- "tendermint-rpc",
+ "tendermint 0.34.0",
+ "tendermint-rpc 0.34.0",
  "thiserror",
  "tokio",
 ]
@@ -892,20 +890,21 @@ dependencies = [
  "sha2 0.10.8",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "treediff",
  "wasmer",
 ]
 
 [[package]]
 name = "cw-orch-core"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad948ad25e5032d8422722455ccea11165cb7179ba7eea23755cb4575d20395"
+checksum = "90742906d091e509f185bb26c07706c037949ddaaa522bb3f3927b53835cc1fd"
 dependencies = [
  "abstract-cw-multi-test",
  "anyhow",
  "cosmwasm-std",
+ "cw-utils 1.0.3",
  "dirs",
  "log",
  "serde",
@@ -916,11 +915,10 @@ dependencies = [
 
 [[package]]
 name = "cw-orch-daemon"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3b27b19c80156b5e51db481e9a9a034e59449ecf74bde687b0f2e5ba73dfbb"
+checksum = "95104f4caf23482ac067d67a787dce34391c548fae496210c4b36bb14c9397d9"
 dependencies = [
- "abstract-cw-multi-test",
  "anyhow",
  "async-recursion",
  "base16",
@@ -941,8 +939,8 @@ dependencies = [
  "ibc-chain-registry",
  "ibc-relayer-types",
  "log",
- "prost 0.11.9",
- "prost-types",
+ "prost 0.12.3",
+ "prost-types 0.11.9",
  "rand_core 0.6.4",
  "reqwest",
  "ring 0.17.6",
@@ -954,14 +952,14 @@ dependencies = [
  "sha256",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
 ]
 
 [[package]]
 name = "cw-orch-networks"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3154369d45874abd908af736a675fc2530bcf2836a7840684554caa6532336"
+checksum = "6a08ab813c374ef74560c661c1c444c3ea0425d14938671fa1c529d6efa348b7"
 dependencies = [
  "cw-orch-core",
  "ibc-chain-registry",
@@ -970,13 +968,13 @@ dependencies = [
 
 [[package]]
 name = "cw-orch-traits"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a5d92716089d3673ce416b7068766b33a918f55b37f2210e386f6ff4c1c1ec"
+checksum = "f786295d8d9754466f8bdb94a67d6c9c647937450bcb4bb12403174800ae1ae7"
 dependencies = [
  "cw-orch-core",
  "prost 0.11.9",
- "prost-types",
+ "prost-types 0.11.9",
 ]
 
 [[package]]
@@ -1802,7 +1800,7 @@ checksum = "1e013a4f0b8772418eee1fc462e74017aba13c364a7b61bd3df1ddcbfe47b065"
 dependencies = [
  "hmac",
  "once_cell",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "rand_core 0.6.4",
  "sha2 0.10.8",
  "subtle-encoding",
@@ -1997,7 +1995,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tendermint-rpc",
+ "tendermint-rpc 0.32.2",
  "tokio",
  "tracing",
 ]
@@ -2015,8 +2013,8 @@ dependencies = [
  "prost 0.11.9",
  "serde",
  "subtle-encoding",
- "tendermint-proto",
- "tonic",
+ "tendermint-proto 0.32.2",
+ "tonic 0.9.2",
 ]
 
 [[package]]
@@ -2041,9 +2039,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.32.2",
  "tendermint-light-client-verifier",
- "tendermint-proto",
+ "tendermint-proto 0.32.2",
  "time",
  "uint",
 ]
@@ -2554,16 +2552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
-
-[[package]]
 name = "peg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,6 +2747,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+dependencies = [
+ "prost 0.12.3",
 ]
 
 [[package]]
@@ -2960,6 +2957,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.9",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3710,11 +3708,40 @@ dependencies = [
  "ed25519-consensus",
  "flex-error",
  "futures",
- "k256",
  "num-traits",
  "once_cell",
  "prost 0.11.9",
- "prost-types",
+ "prost-types 0.11.9",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.10.8",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto 0.32.2",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc2294fa667c8b548ee27a9ba59115472d0a09c2ba255771092a7f1dcf03a789"
+dependencies = [
+ "bytes",
+ "digest 0.10.7",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "k256",
+ "num-traits",
+ "once_cell",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
  "ripemd",
  "serde",
  "serde_bytes",
@@ -3724,7 +3751,7 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.34.0",
  "time",
  "zeroize",
 ]
@@ -3738,7 +3765,21 @@ dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint",
+ "tendermint 0.32.2",
+ "toml",
+ "url",
+]
+
+[[package]]
+name = "tendermint-config"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a25dbe8b953e80f3d61789fbdb83bf9ad6c0ef16df5ca6546f49912542cc137"
+dependencies = [
+ "flex-error",
+ "serde",
+ "serde_json",
+ "tendermint 0.34.0",
  "toml",
  "url",
 ]
@@ -3752,7 +3793,7 @@ dependencies = [
  "derive_more",
  "flex-error",
  "serde",
- "tendermint",
+ "tendermint 0.32.2",
  "time",
 ]
 
@@ -3767,7 +3808,25 @@ dependencies = [
  "num-derive",
  "num-traits",
  "prost 0.11.9",
- "prost-types",
+ "prost-types 0.11.9",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cc728a4f9e891d71adf66af6ecaece146f9c7a11312288a3107b3e1d6979aaf"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive",
+ "num-traits",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -3798,9 +3857,41 @@ dependencies = [
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint",
- "tendermint-config",
- "tendermint-proto",
+ "tendermint 0.32.2",
+ "tendermint-config 0.32.2",
+ "tendermint-proto 0.32.2",
+ "thiserror",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid 0.8.2",
+ "walkdir",
+]
+
+[[package]]
+name = "tendermint-rpc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbf0a4753b46a190f367337e0163d0b552a2674a6bac54e74f9f2cdcde2969b"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "flex-error",
+ "futures",
+ "getrandom",
+ "peg",
+ "pin-project",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "subtle",
+ "subtle-encoding",
+ "tendermint 0.34.0",
+ "tendermint-config 0.34.0",
+ "tendermint-proto 0.34.0",
  "thiserror",
  "time",
  "tokio",
@@ -4004,7 +4095,6 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.5",
@@ -4019,6 +4109,34 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.11.9",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.5",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.12.3",
+ "rustls 0.21.9",
  "rustls-native-certs 0.6.3",
  "rustls-pemfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
  "cw-orch-networks",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "cw20 1.1.2",
  "derivative",
  "env_logger",
@@ -893,6 +894,7 @@ dependencies = [
  "tokio",
  "tonic",
  "treediff",
+ "wasmer",
 ]
 
 [[package]]
@@ -943,7 +945,7 @@ dependencies = [
  "prost-types",
  "rand_core 0.6.4",
  "reqwest",
- "ring 0.17.5",
+ "ring 0.17.6",
  "ripemd",
  "schemars",
  "secp256k1",
@@ -3002,9 +3004,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
 dependencies = [
  "cc",
  "getrandom",
@@ -3118,7 +3120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
 dependencies = [
  "log",
- "ring 0.17.5",
+ "ring 0.17.6",
  "rustls-webpki",
  "sct 0.7.1",
 ]
@@ -3162,7 +3164,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.5",
+ "ring 0.17.6",
  "untrusted 0.9.0",
 ]
 
@@ -3242,7 +3244,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.5",
+ "ring 0.17.6",
  "untrusted 0.9.0",
 ]
 
@@ -3562,9 +3564,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -4530,7 +4532,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.17.5",
+ "ring 0.17.6",
  "untrusted 0.9.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ thiserror = "1.0.50"
 
 # Clone testing deps
 ## Network
-cw-orch-daemon = { version = "0.18.0" }
-cw-orch-networks = { version = "0.18.0" }
+cw-orch-daemon = { version = "0.19.0" }
+cw-orch-networks = { version = "0.19.0" }
 tokio = "1.28.2"
 ibc-chain-registry = "0.25.0"
-tonic = "0.9.2"
+tonic = "0.10.2"
 
 ## Emulation
 cosmwasm-vm = { version = "1.2", features = [
@@ -50,7 +50,7 @@ cosmwasm-vm = { version = "1.2", features = [
 ] }
 
 ## Dual Storage
-cosmrs = "0.14.0"
+cosmrs = "0.15.0"
 num-bigint = "0.4.3"
 
 # Analyzer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,10 @@ treediff = { version = "4.0.2", features = ["with-rustc-serialize"] }
 rustc-serialize = "0.3.24"
 serde_json = "1.0.105"
 log = "0.4.19"
+wasmer = { version = "=4.2.2", default-features = false, features = [
+    "cranelift",
+    "singlepass",
+] }
 
 [dev-dependencies]
 hex = "0.4.3"
@@ -71,3 +75,4 @@ cosmwasm-schema = "1.2.7"
 # Cavern Test App
 cw20 = "1.0.1"
 moneymarket = { git = "https://github.com/CavernPerson/money-market-contracts" }
+cw2 = "1.1.2"

--- a/examples/cavern_test_app.rs
+++ b/examples/cavern_test_app.rs
@@ -61,6 +61,11 @@ pub struct InstantiateMsg {
 pub fn test() -> anyhow::Result<()> {
     env_logger::init();
 
+    let sender = "terra1ytj0hhw39j88qsx4yapsr6ker83jv3aj354gmj";
+    let market = "terra1zqlcp3aty4p4rjv96h6qdascdn953v6crhwedu5vddxjnp349upscluex6";
+    let currency = "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4";
+    let a_currency = "terra1gwdxyqtu75es0x5l6cd9flqhh87zjtj7qdankayyr0vtt7s9w4ssm7ds8m";
+
     let runtime = Runtime::new()?;
     let chain = PHOENIX_1;
     let remote_channel = RemoteChannel::new(&runtime, chain.clone())?;
@@ -84,12 +89,7 @@ pub fn test() -> anyhow::Result<()> {
         })
         .with_api(MockApiBech32::new(chain.network_info.pub_address_prefix));
     let mut app = app.build(|_, _, _| {})?;
-
     // Then we send a message to the blockchain through the app
-    let sender = "terra1ytj0hhw39j88qsx4yapsr6ker83jv3aj354gmj";
-    let market = "terra1zqlcp3aty4p4rjv96h6qdascdn953v6crhwedu5vddxjnp349upscluex6";
-    let currency = "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4";
-    let a_currency = "terra1gwdxyqtu75es0x5l6cd9flqhh87zjtj7qdankayyr0vtt7s9w4ssm7ds8m";
 
     // We query to verify the state changed
     let response: BalanceResponse = app
@@ -133,7 +133,7 @@ pub fn test() -> anyhow::Result<()> {
     .unwrap();
     let counter_contract = WasmContract::new_local(code);
 
-    let code_id = app.store_code(counter_contract);
+    let code_id = app.store_wasm_code(counter_contract);
 
     // We try to instantiate a new contract. Should work ok !
     let contract_addr = app.instantiate_contract(

--- a/examples/counter/contract.rs
+++ b/examples/counter/contract.rs
@@ -1,0 +1,136 @@
+use cosmwasm_std::{
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
+};
+use cw2::set_contract_version;
+
+use crate::counter::{error::*, execute, msg::*, query, state::*};
+
+// version info for migration info
+pub const CONTRACT_NAME: &str = "crates.io:counter";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// ANCHOR: interface_entry
+// ANCHOR: entry_point_line
+#[cfg_attr(feature = "export", entry_point)]
+// ANCHOR_END: entry_point_line
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    let state = State {
+        count: msg.count,
+        owner: info.sender.clone(),
+        cousin: None,
+    };
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    STATE.save(deps.storage, &state)?;
+
+    Ok(Response::new()
+        .add_attribute("method", "instantiate")
+        .add_attribute("owner", info.sender)
+        .add_attribute("count", msg.count.to_string()))
+}
+
+#[cfg_attr(feature = "export", entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Increment {} => execute::increment(deps),
+        ExecuteMsg::Reset { count } => execute::reset(deps, info, count),
+        ExecuteMsg::SetCousin { cousin } => execute::set_cousin(deps, info, cousin),
+    }
+}
+
+#[cfg_attr(feature = "export", entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::GetCount {} => to_json_binary(&query::count(deps)?),
+        QueryMsg::GetCousinCount {} => to_json_binary(&query::cousin_count(deps)?),
+        QueryMsg::GetRawCousinCount {} => to_json_binary(&query::raw_cousin_count(deps)?),
+    }
+}
+
+#[cfg_attr(feature = "export", entry_point)]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    Ok(Response::default().add_attribute("action", "migrate"))
+}
+// ANCHOR_END: interface_entry
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::{
+        coins, from_json,
+        testing::{mock_dependencies, mock_env, mock_info},
+    };
+
+    #[test]
+    fn proper_initialization() {
+        let mut deps = mock_dependencies();
+
+        let msg = InstantiateMsg { count: 17 };
+        let info = mock_info("creator", &coins(1000, "earth"));
+
+        // we can just call .unwrap() to assert this was a success
+        let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+        assert_eq!(0, res.messages.len());
+
+        // it worked, let's query the state
+        let res = query(deps.as_ref(), mock_env(), QueryMsg::GetCount {}).unwrap();
+        let value: GetCountResponse = from_json(res).unwrap();
+        assert_eq!(17, value.count);
+    }
+
+    #[test]
+    fn increment() {
+        let mut deps = mock_dependencies();
+
+        let msg = InstantiateMsg { count: 17 };
+        let info = mock_info("creator", &coins(2, "token"));
+        let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+        // beneficiary can release it
+        let info = mock_info("anyone", &coins(2, "token"));
+        let msg = ExecuteMsg::Increment {};
+        let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+        // should increase counter by 1
+        let res = query(deps.as_ref(), mock_env(), QueryMsg::GetCount {}).unwrap();
+        let value: GetCountResponse = from_json(res).unwrap();
+        assert_eq!(18, value.count);
+    }
+
+    #[test]
+    fn reset() {
+        let mut deps = mock_dependencies();
+
+        let msg = InstantiateMsg { count: 17 };
+        let info = mock_info("creator", &coins(2, "token"));
+        let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+        // beneficiary can release it
+        let unauth_info = mock_info("anyone", &coins(2, "token"));
+        let msg = ExecuteMsg::Reset { count: 5 };
+        let res = execute(deps.as_mut(), mock_env(), unauth_info, msg);
+        match res {
+            Err(ContractError::Unauthorized {}) => {}
+            _ => panic!("Must return unauthorized error"),
+        }
+
+        // only the original creator can reset the counter
+        let auth_info = mock_info("creator", &coins(2, "token"));
+        let msg = ExecuteMsg::Reset { count: 5 };
+        let _res = execute(deps.as_mut(), mock_env(), auth_info, msg).unwrap();
+
+        // should now be 5
+        let res = query(deps.as_ref(), mock_env(), QueryMsg::GetCount {}).unwrap();
+        let value: GetCountResponse = from_json(res).unwrap();
+        assert_eq!(5, value.count);
+    }
+}

--- a/examples/counter/contract.rs
+++ b/examples/counter/contract.rs
@@ -1,6 +1,4 @@
-use cosmwasm_std::{
-    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
-};
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use cw2::set_contract_version;
 
 use crate::counter::{error::*, execute, msg::*, query, state::*};

--- a/examples/counter/error.rs
+++ b/examples/counter/error.rs
@@ -1,0 +1,16 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, PartialEq, Debug)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+
+    #[error("Custom Error val: {val:?}")]
+    CustomError { val: String },
+    // Add any other custom errors you like here.
+    // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.
+}

--- a/examples/counter/execute.rs
+++ b/examples/counter/execute.rs
@@ -1,0 +1,39 @@
+use cosmwasm_std::{DepsMut, MessageInfo, Response};
+
+use crate::counter::{error::*, state::*};
+
+pub fn increment(deps: DepsMut) -> Result<Response, ContractError> {
+    STATE.update(deps.storage, |mut state| -> Result<_, ContractError> {
+        state.count += 1;
+        Ok(state)
+    })?;
+
+    Ok(Response::new().add_attribute("action", "increment"))
+}
+
+pub fn reset(deps: DepsMut, info: MessageInfo, count: i32) -> Result<Response, ContractError> {
+    STATE.update(deps.storage, |mut state| -> Result<_, ContractError> {
+        if info.sender != state.owner {
+            return Err(ContractError::Unauthorized {});
+        }
+        state.count = count;
+        Ok(state)
+    })?;
+    Ok(Response::new().add_attribute("action", "reset"))
+}
+
+pub fn set_cousin(
+    deps: DepsMut,
+    info: MessageInfo,
+    cousin: String,
+) -> Result<Response, ContractError> {
+    let cousin_addr = deps.api.addr_validate(&cousin)?;
+    STATE.update(deps.storage, |mut state| -> Result<_, ContractError> {
+        if info.sender != state.owner {
+            return Err(ContractError::Unauthorized {});
+        }
+        state.cousin = Some(cousin_addr);
+        Ok(state)
+    })?;
+    Ok(Response::new().add_attribute("action", "set_cousin"))
+}

--- a/examples/counter/interface.rs
+++ b/examples/counter/interface.rs
@@ -1,0 +1,65 @@
+// ANCHOR: custom_interface
+use cw_orch::{interface, prelude::*};
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+
+#[interface(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg)]
+pub struct CounterContract;
+
+impl<Chain: CwEnv> Uploadable for CounterContract<Chain> {
+    /// Return the path to the wasm file corresponding to the contract
+    fn wasm(&self) -> WasmPath {
+        artifacts_dir_from_workspace!()
+            .find_wasm_path("counter_contract")
+            .unwrap()
+    }
+    /// Returns a CosmWasm contract wrapper
+    fn wrapper(&self) -> Box<dyn MockContract<Empty>> {
+        Box::new(
+            ContractWrapper::new_with_empty(
+                crate::contract::execute,
+                crate::contract::instantiate,
+                crate::contract::query,
+            )
+            .with_migrate(crate::contract::migrate),
+        )
+    }
+}
+// ANCHOR_END: custom_interface
+
+use crate::contract::CONTRACT_NAME;
+use cw_orch::anyhow::Result;
+use cw_orch::prelude::queriers::Node;
+
+// ANCHOR: daemon
+impl CounterContract<Daemon> {
+    /// Deploys the counter contract at a specific block height
+    pub fn await_launch(&self) -> Result<()> {
+        let daemon = self.get_chain();
+        let rt = daemon.rt_handle.clone();
+
+        rt.block_on(async {
+            // Get the node query client, there are a lot of other clients available.
+            let node = daemon.query_client::<Node>();
+            let mut latest_block = node.latest_block().await.unwrap();
+
+            while latest_block.header.height.value() < 100 {
+                // wait for the next block
+                daemon.next_block().unwrap();
+                latest_block = node.latest_block().await.unwrap();
+            }
+        });
+
+        let contract = CounterContract::new(CONTRACT_NAME, daemon.clone());
+
+        // Upload the contract
+        contract.upload().unwrap();
+
+        // Instantiate the contract
+        let msg = InstantiateMsg { count: 1i32 };
+        contract.instantiate(&msg, None, None).unwrap();
+
+        Ok(())
+    }
+}
+// ANCHOR_END: daemon

--- a/examples/counter/mod.rs
+++ b/examples/counter/mod.rs
@@ -1,0 +1,8 @@
+pub mod contract;
+mod error;
+pub(crate) mod execute;
+pub mod msg;
+pub(crate) mod query;
+pub mod state;
+
+pub use crate::counter::error::ContractError;

--- a/examples/counter/msg.rs
+++ b/examples/counter/msg.rs
@@ -1,0 +1,62 @@
+#![warn(missing_docs)]
+//! # Counter contract
+
+use cosmwasm_schema::{cw_serde, QueryResponses};
+
+#[cw_serde]
+/// Instantiate method for counter
+pub struct InstantiateMsg {
+    /// Initial count
+    pub count: i32,
+}
+
+// ANCHOR: exec_msg
+#[cw_serde]
+#[cfg_attr(feature = "interface", derive(cw_orch::ExecuteFns))] // Function generation
+/// Execute methods for counter
+pub enum ExecuteMsg {
+    /// Increment count by one
+    Increment {},
+    /// Reset count
+    Reset {
+        /// Count value after reset
+        count: i32,
+    },
+    SetCousin {
+        cousin: String,
+    },
+}
+// ANCHOR_END: exec_msg
+
+// ANCHOR: query_msg
+#[cw_serde]
+#[cfg_attr(feature = "interface", derive(cw_orch::QueryFns))] // Function generation
+#[derive(QueryResponses)]
+/// Query methods for counter
+pub enum QueryMsg {
+    /// GetCount returns the current count as a json-encoded number
+    #[returns(GetCountResponse)]
+    GetCount {},
+    /// GetCount returns the current count as a json-encoded number
+    #[returns(GetCountResponse)]
+    GetCousinCount {},
+    /// GetCount returns the current count as a json-encoded number
+    #[returns(GetCountResponse)]
+    GetRawCousinCount {},
+}
+
+// Custom response for the query
+#[cw_serde]
+/// Response from get_count query
+pub struct GetCountResponse {
+    /// Current count in the state
+    pub count: i32,
+}
+// ANCHOR_END: query_msg
+
+#[cw_serde]
+/// Migrate message for count contract
+pub struct MigrateMsg {
+    /// Your favorite type of tea
+    pub t: String,
+}

--- a/examples/counter/query.rs
+++ b/examples/counter/query.rs
@@ -1,0 +1,29 @@
+use cosmwasm_std::{to_json_binary, Deps, QueryRequest, StdResult, WasmQuery};
+
+use crate::counter::{
+    msg::{GetCountResponse, QueryMsg},
+    state::STATE,
+};
+
+pub fn count(deps: Deps) -> StdResult<GetCountResponse> {
+    let state = STATE.load(deps.storage)?;
+    Ok(GetCountResponse { count: state.count })
+}
+
+pub fn cousin_count(deps: Deps) -> StdResult<GetCountResponse> {
+    let state = STATE.load(deps.storage)?;
+    let cousin_count: GetCountResponse =
+        deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+            contract_addr: state.cousin.unwrap().to_string(),
+            msg: to_json_binary(&QueryMsg::GetCount {})?,
+        }))?;
+    Ok(cousin_count)
+}
+
+pub fn raw_cousin_count(deps: Deps) -> StdResult<GetCountResponse> {
+    let state = STATE.load(deps.storage)?;
+    let cousin_state = STATE.query(&deps.querier, state.cousin.unwrap())?;
+    Ok(GetCountResponse {
+        count: cousin_state.count,
+    })
+}

--- a/examples/counter/query.rs
+++ b/examples/counter/query.rs
@@ -7,6 +7,7 @@ use crate::counter::{
 
 pub fn count(deps: Deps) -> StdResult<GetCountResponse> {
     let state = STATE.load(deps.storage)?;
+    println!("Getting the rust code count please");
     Ok(GetCountResponse { count: state.count })
 }
 

--- a/examples/counter/state.rs
+++ b/examples/counter/state.rs
@@ -1,0 +1,14 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct State {
+    pub count: i32,
+    pub owner: Addr,
+    pub cousin: Option<Addr>,
+}
+
+pub const STATE: Item<State> = Item::new("state");

--- a/examples/cousin_test.rs
+++ b/examples/cousin_test.rs
@@ -8,10 +8,7 @@ use cosmwasm_std::{from_json, Addr, Binary, Deps, Empty, Env};
 use counter::msg::{ExecuteMsg, GetCountResponse, QueryMsg};
 use cw_multi_test::{
     addons::{MockAddressGenerator, MockApiBech32},
-    wasm_emulation::{
-        channel::RemoteChannel,
-        contract::{LocalWasmContract, WasmContract},
-    },
+    wasm_emulation::{channel::RemoteChannel, contract::WasmContract},
     App, AppBuilder, BankKeeper, ContractWrapper, Executor, WasmKeeper,
 };
 use cw_orch_networks::networks::PHOENIX_1;

--- a/examples/cousin_test.rs
+++ b/examples/cousin_test.rs
@@ -1,0 +1,161 @@
+fn main() {
+    test().unwrap()
+}
+use std::path::Path;
+
+use anyhow::Result as AnyResult;
+use cosmwasm_std::{from_json, Addr, Binary, Deps, Empty, Env};
+use counter::msg::{ExecuteMsg, GetCountResponse, QueryMsg};
+use cw_multi_test::{
+    addons::{MockAddressGenerator, MockApiBech32},
+    wasm_emulation::{
+        channel::RemoteChannel,
+        contract::{LocalWasmContract, WasmContract},
+    },
+    App, AppBuilder, BankKeeper, ContractWrapper, Executor, WasmKeeper,
+};
+use cw_orch_networks::networks::PHOENIX_1;
+use tokio::runtime::Runtime;
+
+mod counter;
+
+fn query(deps: Deps, env: Env, msg: Vec<u8>) -> AnyResult<Binary> {
+    counter::contract::query(deps, env, from_json(msg)?).map_err(Into::into)
+}
+
+pub const SENDER: &str = "terra17c6ts8grcfrgquhj3haclg44le8s7qkx6l2yx33acguxhpf000xqhnl3je";
+fn increment(app: &mut App<BankKeeper, MockApiBech32>, contract: Addr) -> AnyResult<()> {
+    let sender = Addr::unchecked(SENDER);
+    app.execute_contract(
+        sender.clone(),
+        contract.clone(),
+        &ExecuteMsg::Increment {},
+        &[],
+    )?;
+    Ok(())
+}
+
+fn count(app: &App<BankKeeper, MockApiBech32>, contract: Addr) -> AnyResult<GetCountResponse> {
+    Ok(app
+        .wrap()
+        .query_wasm_smart(contract.clone(), &QueryMsg::GetCount {})?)
+}
+
+fn raw_cousin_count(
+    app: &App<BankKeeper, MockApiBech32>,
+    contract: Addr,
+) -> AnyResult<GetCountResponse> {
+    Ok(app
+        .wrap()
+        .query_wasm_smart(contract.clone(), &QueryMsg::GetRawCousinCount {})?)
+}
+
+fn cousin_count(
+    app: &App<BankKeeper, MockApiBech32>,
+    contract: Addr,
+) -> AnyResult<GetCountResponse> {
+    Ok(app
+        .wrap()
+        .query_wasm_smart(contract.clone(), &QueryMsg::GetCousinCount {})?)
+}
+
+fn test() -> AnyResult<()> {
+    env_logger::init();
+    let rust_contract = ContractWrapper::new(
+        counter::contract::execute,
+        counter::contract::instantiate,
+        counter::contract::query,
+    );
+
+    let code = std::fs::read(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("artifacts")
+            .join("counter_contract_with_cousin.wasm"),
+    )
+    .unwrap();
+    let wasm_contract = WasmContract::new_local(code);
+
+    let runtime = Runtime::new()?;
+    let chain = PHOENIX_1;
+    let remote_channel = RemoteChannel::new(&runtime, chain.clone())?;
+
+    let wasm = WasmKeeper::<Empty, Empty>::new()
+        .with_remote(remote_channel.clone())
+        .with_address_generator(MockAddressGenerator);
+
+    let bank = BankKeeper::new().with_remote(remote_channel.clone());
+
+    // First we instantiate a new app
+    let mut app = AppBuilder::default()
+        .with_wasm(wasm)
+        .with_bank(bank)
+        .with_remote(remote_channel)
+        .with_api(MockApiBech32::new(chain.network_info.pub_address_prefix))
+        .build(|_, _, _| {})?;
+
+    let sender = Addr::unchecked(SENDER);
+    let rust_code_id = app.store_code((Box::new(rust_contract), query));
+    let wasm_code_id = app.store_wasm_code(wasm_contract);
+
+    let counter_rust = app
+        .instantiate_contract(
+            rust_code_id,
+            sender.clone(),
+            &counter::msg::InstantiateMsg { count: 1 },
+            &[],
+            "cousin-counter",
+            Some(sender.to_string()),
+        )
+        .unwrap();
+
+    let counter_wasm = app
+        .instantiate_contract(
+            wasm_code_id,
+            sender.clone(),
+            &counter::msg::InstantiateMsg { count: 1 },
+            &[],
+            "cousin-counter",
+            Some(sender.to_string()),
+        )
+        .unwrap();
+
+    println!("Rust contract {}", counter_rust);
+    println!("Wasm contract {}", counter_wasm);
+
+    app.execute_contract(
+        sender.clone(),
+        counter_rust.clone(),
+        &ExecuteMsg::SetCousin {
+            cousin: counter_wasm.to_string(),
+        },
+        &[],
+    )?;
+
+    app.execute_contract(
+        sender.clone(),
+        counter_wasm.clone(),
+        &ExecuteMsg::SetCousin {
+            cousin: counter_rust.to_string(),
+        },
+        &[],
+    )?;
+
+    // Increment the count on both and see what's what
+    increment(&mut app, counter_rust.clone())?;
+    increment(&mut app, counter_rust.clone())?;
+    increment(&mut app, counter_wasm.clone())?;
+
+    // Assert the count
+    assert_eq!(count(&app, counter_rust.clone())?.count, 3);
+    assert_eq!(count(&app, counter_wasm.clone())?.count, 2);
+
+    // Assert the raw cousin count
+    assert_eq!(raw_cousin_count(&app, counter_rust.clone())?.count, 2);
+    assert_eq!(raw_cousin_count(&app, counter_wasm.clone())?.count, 3);
+
+    // Assert the cousin count
+    assert_eq!(cousin_count(&app, counter_rust.clone())?.count, 2);
+    assert_eq!(cousin_count(&app, counter_wasm.clone())?.count, 3);
+
+    Ok(())
+}

--- a/examples/cousin_test.rs
+++ b/examples/cousin_test.rs
@@ -4,7 +4,7 @@ fn main() {
 use std::path::Path;
 
 use anyhow::Result as AnyResult;
-use cosmwasm_std::{from_json, Addr, Binary, Deps, Empty, Env};
+use cosmwasm_std::{Addr, Empty};
 use counter::msg::{ExecuteMsg, GetCountResponse, QueryMsg};
 use cw_multi_test::{
     addons::{MockAddressGenerator, MockApiBech32},
@@ -15,10 +15,6 @@ use cw_orch_networks::networks::PHOENIX_1;
 use tokio::runtime::Runtime;
 
 mod counter;
-
-fn query(deps: Deps, env: Env, msg: Vec<u8>) -> AnyResult<Binary> {
-    counter::contract::query(deps, env, from_json(msg)?).map_err(Into::into)
-}
 
 pub const SENDER: &str = "terra17c6ts8grcfrgquhj3haclg44le8s7qkx6l2yx33acguxhpf000xqhnl3je";
 fn increment(app: &mut App<BankKeeper, MockApiBech32>, contract: Addr) -> AnyResult<()> {
@@ -91,7 +87,7 @@ fn test() -> AnyResult<()> {
         .build(|_, _, _| {})?;
 
     let sender = Addr::unchecked(SENDER);
-    let rust_code_id = app.store_code((Box::new(rust_contract), query));
+    let rust_code_id = app.store_code(Box::new(rust_contract));
     let wasm_code_id = app.store_wasm_code(wasm_contract);
 
     let counter_rust = app

--- a/src/app.rs
+++ b/src/app.rs
@@ -325,7 +325,7 @@ where
             storage, remote, ..
         } = self;
 
-        let mut addresses = ADDRESSES.may_load(storage).unwrap().unwrap_or(vec![]);
+        let mut addresses = ADDRESSES.may_load(storage).unwrap().unwrap_or_default();
 
         let new_address =
             RealApi::new(&remote.chain.bech32_prefix.clone()).next_address(addresses.len());

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crate::wasm_emulation::api::RealApi;
 use crate::wasm_emulation::channel::RemoteChannel;
-use crate::wasm_emulation::input::{BankStorage, QuerierStorage, WasmStorage};
+use crate::wasm_emulation::input::QuerierStorage;
 use cosmwasm_std::CustomMsg;
 use cw_storage_plus::Item;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use crate::ibc::Ibc;
 use crate::module::{FailingModule, Module};
 use crate::staking::{Distribution, DistributionKeeper, StakeKeeper, Staking, StakingSudo};
 use crate::transactions::transactional;
-use crate::wasm::{ContractData, RawQueryFunc, Wasm, WasmKeeper, WasmSudo};
+use crate::wasm::{ContractData, Wasm, WasmKeeper, WasmSudo};
 use crate::wasm_emulation::contract::WasmContract;
 use crate::{AppBuilder, Contract, GovFailingModule, IbcFailingModule};
 use cosmwasm_std::testing::{MockApi, MockStorage};
@@ -247,13 +247,7 @@ where
 
     /// Registers contract code (like uploading wasm bytecode on a chain),
     /// so it can later be used to instantiate a contract.
-    pub fn store_code(
-        &mut self,
-        code: (
-            Box<dyn Contract<CustomT::ExecT, CustomT::QueryT>>,
-            RawQueryFunc<CustomT::QueryT>,
-        ),
-    ) -> u64 {
+    pub fn store_code(&mut self, code: Box<dyn Contract<CustomT::ExecT, CustomT::QueryT>>) -> u64 {
         self.init_modules(|router, _, _| {
             router
                 .wasm
@@ -272,10 +266,7 @@ where
     pub fn store_code_with_creator(
         &mut self,
         creator: Addr,
-        code: (
-            Box<dyn Contract<CustomT::ExecT, CustomT::QueryT>>,
-            RawQueryFunc<CustomT::QueryT>,
-        ),
+        code: Box<dyn Contract<CustomT::ExecT, CustomT::QueryT>>,
     ) -> u64 {
         self.init_modules(|router, _, _| router.wasm.store_code(creator, code))
     }
@@ -671,7 +662,7 @@ where
         panic!("Cannot sudo MockRouters");
     }
 
-    fn get_querier_storage(&self, storage: &dyn Storage) -> AnyResult<QuerierStorage> {
+    fn get_querier_storage(&self, _storage: &dyn Storage) -> AnyResult<QuerierStorage> {
         Ok(QuerierStorage::default())
     }
 }

--- a/src/app_builder.rs
+++ b/src/app_builder.rs
@@ -143,6 +143,7 @@ impl<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>
 where
     CustomT: Module,
     WasmT: Wasm<CustomT::ExecT, CustomT::QueryT>,
+    CustomT::QueryT: CustomQuery,
 {
     /// Overwrites the default wasm executor.
     ///

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -5,10 +5,11 @@ use crate::module::Module;
 use crate::prefixed_storage::{prefixed, prefixed_read};
 use crate::queries::bank::BankRemoteQuerier;
 use crate::wasm_emulation::channel::RemoteChannel;
-use crate::wasm_emulation::query::AllQuerier;
+use crate::wasm_emulation::input::BankStorage;
+use crate::wasm_emulation::query::AllBankQuerier;
 use cosmwasm_std::{
     coin, to_json_binary, Addr, AllBalanceResponse, Api, BalanceResponse, BankMsg, BankQuery,
-    Binary, BlockInfo, Coin, Event, Querier, Storage,
+    Binary, BlockInfo, Coin, Event, Querier, Storage, Order,
 };
 #[cfg(feature = "cosmwasm_1_1")]
 use cosmwasm_std::{Order, StdResult, SupplyResponse, Uint128};
@@ -29,7 +30,10 @@ pub enum BankSudo {
     },
 }
 
-pub trait Bank: Module<ExecT = BankMsg, QueryT = BankQuery, SudoT = BankSudo> + AllQuerier {}
+pub trait Bank:
+    Module<ExecT = BankMsg, QueryT = BankQuery, SudoT = BankSudo> + AllBankQuerier
+{
+}
 
 #[derive(Default)]
 pub struct BankKeeper {
@@ -246,5 +250,15 @@ impl Module for BankKeeper {
             }
             q => bail!("Unsupported bank query: {:?}", q),
         }
+    }
+}
+
+impl AllBankQuerier for BankKeeper {
+    fn query_all(&self, storage: &dyn Storage) -> AnyResult<BankStorage> {
+        let bank_storage = prefixed_read(storage, NAMESPACE_BANK);
+        let balances: Result<Vec<_>, _> = BALANCES
+            .range(&bank_storage, None, None, Order::Ascending)
+            .collect();
+        Ok(BankStorage { storage: balances? })
     }
 }

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -12,7 +12,7 @@ use cosmwasm_std::{
     Binary, BlockInfo, Coin, Event, Order, Querier, Storage,
 };
 #[cfg(feature = "cosmwasm_1_1")]
-use cosmwasm_std::{Order, StdResult, SupplyResponse, Uint128};
+use cosmwasm_std::{StdResult, SupplyResponse, Uint128};
 use cw_storage_plus::Map;
 use cw_utils::NativeBalance;
 use itertools::Itertools;

--- a/src/bank.rs
+++ b/src/bank.rs
@@ -9,7 +9,7 @@ use crate::wasm_emulation::input::BankStorage;
 use crate::wasm_emulation::query::AllBankQuerier;
 use cosmwasm_std::{
     coin, to_json_binary, Addr, AllBalanceResponse, Api, BalanceResponse, BankMsg, BankQuery,
-    Binary, BlockInfo, Coin, Event, Querier, Storage, Order,
+    Binary, BlockInfo, Coin, Event, Order, Querier, Storage,
 };
 #[cfg(feature = "cosmwasm_1_1")]
 use cosmwasm_std::{Order, StdResult, SupplyResponse, Uint128};

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -14,11 +14,11 @@ use cosmwasm_std::{
 use anyhow::Result as AnyResult;
 use serde::de::DeserializeOwned;
 
-use crate::{
-    prefixed_storage::{PrefixedStorage, ReadonlyPrefixedStorage},
-    wasm_emulation::{
-        query::{mock_querier::ForkState, MockQuerier},
-        storage::dual_std_storage::DualStorage,
+use crate::wasm_emulation::{
+    query::{mock_querier::ForkState, MockQuerier},
+    storage::{
+        dual_std_storage::DualStorage,
+        storage_wrappers::{ReadonlyStorageWrapper, StorageWrapper},
     },
 };
 use anyhow::{anyhow, bail};
@@ -314,7 +314,7 @@ where
         let mut storage = DualStorage::new(
             fork_state.remote,
             env.contract.address.to_string(),
-            Box::new(PrefixedStorage::new(deps.storage, &[])),
+            Box::new(StorageWrapper::new(deps.storage)),
         )?;
         let deps = DepsMut {
             storage: &mut storage,
@@ -338,7 +338,7 @@ where
         let mut storage = DualStorage::new(
             fork_state.remote,
             env.contract.address.to_string(),
-            Box::new(PrefixedStorage::new(deps.storage, &[])),
+            Box::new(StorageWrapper::new(deps.storage)),
         )?;
         let deps = DepsMut {
             storage: &mut storage,
@@ -360,7 +360,7 @@ where
         let mut storage = DualStorage::new(
             fork_state.remote,
             env.contract.address.to_string(),
-            Box::new(ReadonlyPrefixedStorage::new(deps.storage, &[])),
+            Box::new(ReadonlyStorageWrapper::new(deps.storage)),
         )?;
         let deps = Deps {
             storage: &mut storage,
@@ -383,7 +383,7 @@ where
         let mut storage = DualStorage::new(
             fork_state.remote,
             env.contract.address.to_string(),
-            Box::new(PrefixedStorage::new(deps.storage, &[])),
+            Box::new(StorageWrapper::new(deps.storage)),
         )?;
         let deps = DepsMut {
             storage: &mut storage,
@@ -409,7 +409,7 @@ where
         let mut storage = DualStorage::new(
             fork_state.remote,
             env.contract.address.to_string(),
-            Box::new(PrefixedStorage::new(deps.storage, &[])),
+            Box::new(StorageWrapper::new(deps.storage)),
         )?;
         let deps = DepsMut {
             storage: &mut storage,
@@ -434,7 +434,7 @@ where
         let mut storage = DualStorage::new(
             fork_state.remote,
             env.contract.address.to_string(),
-            Box::new(PrefixedStorage::new(deps.storage, &[])),
+            Box::new(StorageWrapper::new(deps.storage)),
         )?;
         let deps = DepsMut {
             storage: &mut storage,

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -1,16 +1,26 @@
+use std::{
+    error::Error,
+    fmt::{self, Debug, Display},
+    ops::Deref,
+};
+
 use schemars::JsonSchema;
 
-use cosmwasm_std::{Binary, CustomQuery, Deps, DepsMut, Empty, Env, MessageInfo, Reply, Response};
+use cosmwasm_std::{
+    from_json, Binary, CosmosMsg, CustomMsg, CustomQuery, Deps, DepsMut, Empty, Env, MessageInfo,
+    QuerierWrapper, Reply, Response, StdError, SubMsg,
+};
 
 use anyhow::Result as AnyResult;
+use serde::de::DeserializeOwned;
 
-use crate::wasm_emulation::channel::RemoteChannel;
-
+use crate::wasm_emulation::{channel::RemoteChannel, query::mock_querier::ForkState};
+use anyhow::{anyhow, bail};
 /// Interface to call into a [Contract].
 pub trait Contract<T, Q = Empty>
 where
-    T: Clone + std::fmt::Debug + PartialEq + JsonSchema,
-    Q: CustomQuery,
+    T: CustomMsg + DeserializeOwned + Clone + std::fmt::Debug + PartialEq + JsonSchema,
+    Q: CustomQuery + DeserializeOwned,
 {
     fn execute(
         &self,
@@ -18,7 +28,7 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        remote: RemoteChannel,
+        fork_state: ForkState<Q>,
     ) -> AnyResult<Response<T>>;
 
     fn instantiate(
@@ -27,7 +37,7 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        remote: RemoteChannel,
+        fork_state: ForkState<Q>,
     ) -> AnyResult<Response<T>>;
 
     fn query(
@@ -35,7 +45,7 @@ where
         deps: Deps<Q>,
         env: Env,
         msg: Vec<u8>,
-        remote: RemoteChannel,
+        fork_state: ForkState<Q>,
     ) -> AnyResult<Binary>;
 
     fn sudo(
@@ -43,7 +53,7 @@ where
         deps: DepsMut<Q>,
         env: Env,
         msg: Vec<u8>,
-        remote: RemoteChannel,
+        fork_state: ForkState<Q>,
     ) -> AnyResult<Response<T>>;
 
     fn reply(
@@ -51,7 +61,7 @@ where
         deps: DepsMut<Q>,
         env: Env,
         msg: Reply,
-        remote: RemoteChannel,
+        fork_state: ForkState<Q>,
     ) -> AnyResult<Response<T>>;
 
     fn migrate(
@@ -59,6 +69,357 @@ where
         deps: DepsMut<Q>,
         env: Env,
         msg: Vec<u8>,
-        remote: RemoteChannel,
+        fork_state: ForkState<Q>,
     ) -> AnyResult<Response<T>>;
+}
+
+type ContractFn<T, C, E, Q> =
+    fn(deps: DepsMut<Q>, env: Env, info: MessageInfo, msg: T) -> Result<Response<C>, E>;
+type PermissionedFn<T, C, E, Q> = fn(deps: DepsMut<Q>, env: Env, msg: T) -> Result<Response<C>, E>;
+type ReplyFn<C, E, Q> = fn(deps: DepsMut<Q>, env: Env, msg: Reply) -> Result<Response<C>, E>;
+type QueryFn<T, E, Q> = fn(deps: Deps<Q>, env: Env, msg: T) -> Result<Binary, E>;
+
+type ContractClosure<T, C, E, Q> = fn(DepsMut<Q>, Env, MessageInfo, T) -> Result<Response<C>, E>;
+type PermissionedClosure<T, C, E, Q> = fn(DepsMut<Q>, Env, T) -> Result<Response<C>, E>;
+type ReplyClosure<C, E, Q> = fn(DepsMut<Q>, Env, Reply) -> Result<Response<C>, E>;
+type QueryClosure<T, E, Q> = fn(Deps<Q>, Env, T) -> Result<Binary, E>;
+
+#[derive(Clone, Copy)]
+/// Wraps the exported functions from a contract and provides the normalized format
+/// Place T4 and E4 at the end, as we just want default placeholders for most contracts that don't have sudo
+pub struct ContractWrapper<
+    T1,
+    T2,
+    T3,
+    E1,
+    E2,
+    E3,
+    C = Empty,
+    Q = Empty,
+    T4 = Empty,
+    E4 = StdError,
+    E5 = StdError,
+    T6 = Empty,
+    E6 = StdError,
+> where
+    T1: DeserializeOwned + Debug,
+    T2: DeserializeOwned,
+    T3: DeserializeOwned,
+    T4: DeserializeOwned,
+    T6: DeserializeOwned,
+    E1: Display + Debug + Send + Sync + 'static,
+    E2: Display + Debug + Send + Sync + 'static,
+    E3: Display + Debug + Send + Sync + 'static,
+    E4: Display + Debug + Send + Sync + 'static,
+    E5: Display + Debug + Send + Sync + 'static,
+    E6: Display + Debug + Send + Sync + 'static,
+    C: Clone + fmt::Debug + PartialEq + JsonSchema,
+    Q: CustomQuery + DeserializeOwned + 'static,
+{
+    execute_fn: ContractClosure<T1, C, E1, Q>,
+    instantiate_fn: ContractClosure<T2, C, E2, Q>,
+    pub query_fn: QueryClosure<T3, E3, Q>,
+    sudo_fn: Option<PermissionedClosure<T4, C, E4, Q>>,
+    reply_fn: Option<ReplyClosure<C, E5, Q>>,
+    migrate_fn: Option<PermissionedClosure<T6, C, E6, Q>>,
+}
+
+impl<T1, T2, T3, E1, E2, E3, C, Q> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q>
+where
+    T1: DeserializeOwned + Debug + 'static,
+    T2: DeserializeOwned + 'static,
+    T3: DeserializeOwned + 'static,
+    E1: Display + Debug + Send + Sync + 'static,
+    E2: Display + Debug + Send + Sync + 'static,
+    E3: Display + Debug + Send + Sync + 'static,
+    C: Clone + fmt::Debug + PartialEq + JsonSchema + 'static,
+    Q: CustomQuery + DeserializeOwned + 'static,
+{
+    pub fn new(
+        execute_fn: ContractFn<T1, C, E1, Q>,
+        instantiate_fn: ContractFn<T2, C, E2, Q>,
+        query_fn: QueryFn<T3, E3, Q>,
+    ) -> Self {
+        Self {
+            execute_fn,
+            instantiate_fn,
+            query_fn,
+            sudo_fn: None,
+            reply_fn: None,
+            migrate_fn: None,
+        }
+    }
+}
+
+impl<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6, E6>
+    ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6, E6>
+where
+    T1: DeserializeOwned + Debug + 'static,
+    T2: DeserializeOwned + 'static,
+    T3: DeserializeOwned + 'static,
+    T4: DeserializeOwned + 'static,
+    T6: DeserializeOwned + 'static,
+    E1: Display + Debug + Send + Sync + 'static,
+    E2: Display + Debug + Send + Sync + 'static,
+    E3: Display + Debug + Send + Sync + 'static,
+    E4: Display + Debug + Send + Sync + 'static,
+    E5: Display + Debug + Send + Sync + 'static,
+    E6: Display + Debug + Send + Sync + 'static,
+    C: Clone + fmt::Debug + PartialEq + JsonSchema + 'static,
+    Q: CustomQuery + DeserializeOwned + 'static,
+{
+    pub fn with_sudo<T4A, E4A>(
+        self,
+        sudo_fn: PermissionedFn<T4A, C, E4A, Q>,
+    ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4A, E4A, E5, T6, E6>
+    where
+        T4A: DeserializeOwned + 'static,
+        E4A: Display + Debug + Send + Sync + 'static,
+    {
+        ContractWrapper {
+            execute_fn: self.execute_fn,
+            instantiate_fn: self.instantiate_fn,
+            query_fn: self.query_fn,
+            sudo_fn: Some(sudo_fn),
+            reply_fn: self.reply_fn,
+            migrate_fn: self.migrate_fn,
+        }
+    }
+
+    pub fn with_reply<E5A>(
+        self,
+        reply_fn: ReplyFn<C, E5A, Q>,
+    ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5A, T6, E6>
+    where
+        E5A: Display + Debug + Send + Sync + 'static,
+    {
+        ContractWrapper {
+            execute_fn: self.execute_fn,
+            instantiate_fn: self.instantiate_fn,
+            query_fn: self.query_fn,
+            sudo_fn: self.sudo_fn,
+            reply_fn: Some(reply_fn),
+            migrate_fn: self.migrate_fn,
+        }
+    }
+
+    pub fn with_migrate<T6A, E6A>(
+        self,
+        migrate_fn: PermissionedFn<T6A, C, E6A, Q>,
+    ) -> ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6A, E6A>
+    where
+        T6A: DeserializeOwned + 'static,
+        E6A: Display + Debug + Send + Sync + 'static,
+    {
+        ContractWrapper {
+            execute_fn: self.execute_fn,
+            instantiate_fn: self.instantiate_fn,
+            query_fn: self.query_fn,
+            sudo_fn: self.sudo_fn,
+            reply_fn: self.reply_fn,
+            migrate_fn: Some(migrate_fn),
+        }
+    }
+}
+
+fn decustomize_deps_mut<'a, Q>(deps: &'a mut DepsMut<Q>) -> DepsMut<'a, Empty>
+where
+    Q: CustomQuery + DeserializeOwned + 'static,
+{
+    DepsMut {
+        storage: deps.storage,
+        api: deps.api,
+        querier: QuerierWrapper::new(deps.querier.deref()),
+    }
+}
+
+fn decustomize_deps<'a, Q>(deps: &'a Deps<'a, Q>) -> Deps<'a, Empty>
+where
+    Q: CustomQuery + DeserializeOwned + 'static,
+{
+    Deps {
+        storage: deps.storage,
+        api: deps.api,
+        querier: QuerierWrapper::new(deps.querier.deref()),
+    }
+}
+
+fn customize_response<C>(resp: Response<Empty>) -> Response<C>
+where
+    C: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
+    let mut customized_resp = Response::<C>::new()
+        .add_submessages(resp.messages.into_iter().map(customize_msg::<C>))
+        .add_events(resp.events)
+        .add_attributes(resp.attributes);
+    customized_resp.data = resp.data;
+    customized_resp
+}
+
+fn customize_msg<C>(msg: SubMsg<Empty>) -> SubMsg<C>
+where
+    C: Clone + fmt::Debug + PartialEq + JsonSchema,
+{
+    SubMsg {
+        msg: match msg.msg {
+            CosmosMsg::Wasm(wasm) => CosmosMsg::Wasm(wasm),
+            CosmosMsg::Bank(bank) => CosmosMsg::Bank(bank),
+            CosmosMsg::Staking(staking) => CosmosMsg::Staking(staking),
+            CosmosMsg::Distribution(distribution) => CosmosMsg::Distribution(distribution),
+            CosmosMsg::Custom(_) => unreachable!(),
+            #[cfg(feature = "stargate")]
+            CosmosMsg::Ibc(ibc) => CosmosMsg::Ibc(ibc),
+            #[cfg(feature = "stargate")]
+            CosmosMsg::Stargate { type_url, value } => CosmosMsg::Stargate { type_url, value },
+            _ => panic!("unknown message variant {:?}", msg),
+        },
+        id: msg.id,
+        gas_limit: msg.gas_limit,
+        reply_on: msg.reply_on,
+    }
+}
+
+impl<T1, T2, T3, E1, E2, E3, C, T4, E4, E5, T6, E6, Q> Contract<C, Q>
+    for ContractWrapper<T1, T2, T3, E1, E2, E3, C, Q, T4, E4, E5, T6, E6>
+where
+    T1: DeserializeOwned + Debug + Clone,
+    T2: DeserializeOwned + Debug + Clone,
+    T3: DeserializeOwned + Debug + Clone,
+    T4: DeserializeOwned,
+    T6: DeserializeOwned,
+    E1: Display + Debug + Send + Sync + Error + 'static,
+    E2: Display + Debug + Send + Sync + Error + 'static,
+    E3: Display + Debug + Send + Sync + Error + 'static,
+    E4: Display + Debug + Send + Sync + 'static,
+    E5: Display + Debug + Send + Sync + 'static,
+    E6: Display + Debug + Send + Sync + 'static,
+    C: CustomMsg + DeserializeOwned + Clone + fmt::Debug + PartialEq + JsonSchema,
+    Q: CustomQuery + DeserializeOwned,
+{
+    fn execute(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        info: MessageInfo,
+        msg: Vec<u8>,
+        _fork_state: ForkState<Q>,
+    ) -> AnyResult<Response<C>> {
+        let msg: T1 = from_json(&msg)?;
+        (self.execute_fn)(deps, env, info, msg).map_err(|err| anyhow!(err))
+    }
+
+    fn instantiate(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        info: MessageInfo,
+        msg: Vec<u8>,
+        _fork_state: ForkState<Q>,
+    ) -> AnyResult<Response<C>> {
+        let msg: T2 = from_json(&msg)?;
+        (self.instantiate_fn)(deps, env, info, msg).map_err(|err| anyhow!(err))
+    }
+
+    fn query(
+        &self,
+        deps: Deps<Q>,
+        env: Env,
+        msg: Vec<u8>,
+        _fork_state: ForkState<Q>,
+    ) -> AnyResult<Binary> {
+        let msg: T3 = from_json(&msg)?;
+        (self.query_fn)(deps, env, msg).map_err(|err| anyhow!(err))
+    }
+
+    // this returns an error if the contract doesn't implement sudo
+    fn sudo(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: Vec<u8>,
+        _fork_state: ForkState<Q>,
+    ) -> AnyResult<Response<C>> {
+        let msg = from_json(&msg)?;
+        match &self.sudo_fn {
+            Some(sudo) => sudo(deps, env, msg).map_err(|err| anyhow!(err)),
+            None => bail!("sudo not implemented for contract"),
+        }
+    }
+
+    // this returns an error if the contract doesn't implement reply
+    fn reply(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        reply_data: Reply,
+        _fork_state: ForkState<Q>,
+    ) -> AnyResult<Response<C>> {
+        match &self.reply_fn {
+            Some(reply) => reply(deps, env, reply_data).map_err(|err| anyhow!(err)),
+            None => bail!("reply not implemented for contract"),
+        }
+    }
+
+    // this returns an error if the contract doesn't implement migrate
+    fn migrate(
+        &self,
+        deps: DepsMut<Q>,
+        env: Env,
+        msg: Vec<u8>,
+        _fork_state: ForkState<Q>,
+    ) -> AnyResult<Response<C>> {
+        let msg = from_json(&msg)?;
+        match &self.migrate_fn {
+            Some(migrate) => migrate(deps, env, msg).map_err(|err| anyhow!(err)),
+            None => bail!("migrate not implemented for contract"),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use std::error::Error;
+
+    use cosmwasm_std::{
+        testing::{mock_dependencies, mock_env, mock_info},
+        to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult,
+    };
+
+    use super::ContractWrapper;
+
+    fn execute(deps: DepsMut, env: Env, info: MessageInfo, _msg: Empty) -> StdResult<Response> {
+        Ok(Response::new())
+    }
+
+    fn query(deps: Deps, env: Env, _msg: Empty) -> StdResult<Binary> {
+        Ok(to_json_binary("resp")?)
+    }
+
+    fn instantiate(deps: DepsMut, env: Env, info: MessageInfo, _msg: Empty) -> StdResult<Response> {
+        Ok(Response::new())
+    }
+
+    #[test]
+    fn mock_contract() -> anyhow::Result<()> {
+        let contract = ContractWrapper::new(execute, instantiate, query);
+
+        let clone = contract.execute_fn;
+        let second_clone = clone;
+
+        clone(
+            mock_dependencies().as_mut(),
+            mock_env(),
+            mock_info("sender", &[]),
+            Empty {},
+        )?;
+
+        second_clone(
+            mock_dependencies().as_mut(),
+            mock_env(),
+            mock_info("sender", &[]),
+            Empty {},
+        )?;
+
+        Ok(())
+    }
 }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -28,7 +28,7 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        fork_state: ForkState<Q>,
+        fork_state: ForkState<T, Q>,
     ) -> AnyResult<Response<T>>;
 
     fn instantiate(
@@ -37,7 +37,7 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        fork_state: ForkState<Q>,
+        fork_state: ForkState<T, Q>,
     ) -> AnyResult<Response<T>>;
 
     fn query(
@@ -45,7 +45,7 @@ where
         deps: Deps<Q>,
         env: Env,
         msg: Vec<u8>,
-        fork_state: ForkState<Q>,
+        fork_state: ForkState<T, Q>,
     ) -> AnyResult<Binary>;
 
     fn sudo(
@@ -53,7 +53,7 @@ where
         deps: DepsMut<Q>,
         env: Env,
         msg: Vec<u8>,
-        fork_state: ForkState<Q>,
+        fork_state: ForkState<T, Q>,
     ) -> AnyResult<Response<T>>;
 
     fn reply(
@@ -61,7 +61,7 @@ where
         deps: DepsMut<Q>,
         env: Env,
         msg: Reply,
-        fork_state: ForkState<Q>,
+        fork_state: ForkState<T, Q>,
     ) -> AnyResult<Response<T>>;
 
     fn migrate(
@@ -69,7 +69,7 @@ where
         deps: DepsMut<Q>,
         env: Env,
         msg: Vec<u8>,
-        fork_state: ForkState<Q>,
+        fork_state: ForkState<T, Q>,
     ) -> AnyResult<Response<T>>;
 }
 
@@ -302,7 +302,7 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        _fork_state: ForkState<Q>,
+        _fork_state: ForkState<C, Q>,
     ) -> AnyResult<Response<C>> {
         let msg: T1 = from_json(msg)?;
         (self.execute_fn)(deps, env, info, msg).map_err(|err| anyhow!(err))
@@ -314,7 +314,7 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        _fork_state: ForkState<Q>,
+        _fork_state: ForkState<C, Q>,
     ) -> AnyResult<Response<C>> {
         let msg: T2 = from_json(msg)?;
         (self.instantiate_fn)(deps, env, info, msg).map_err(|err| anyhow!(err))
@@ -325,7 +325,7 @@ where
         deps: Deps<Q>,
         env: Env,
         msg: Vec<u8>,
-        _fork_state: ForkState<Q>,
+        _fork_state: ForkState<C, Q>,
     ) -> AnyResult<Binary> {
         let msg: T3 = from_json(msg)?;
         (self.query_fn)(deps, env, msg).map_err(|err| anyhow!(err))
@@ -337,7 +337,7 @@ where
         deps: DepsMut<Q>,
         env: Env,
         msg: Vec<u8>,
-        _fork_state: ForkState<Q>,
+        _fork_state: ForkState<C, Q>,
     ) -> AnyResult<Response<C>> {
         let msg = from_json(msg)?;
         match &self.sudo_fn {
@@ -352,7 +352,7 @@ where
         deps: DepsMut<Q>,
         env: Env,
         reply_data: Reply,
-        _fork_state: ForkState<Q>,
+        _fork_state: ForkState<C, Q>,
     ) -> AnyResult<Response<C>> {
         match &self.reply_fn {
             Some(reply) => reply(deps, env, reply_data).map_err(|err| anyhow!(err)),
@@ -366,7 +366,7 @@ where
         deps: DepsMut<Q>,
         env: Env,
         msg: Vec<u8>,
-        _fork_state: ForkState<Q>,
+        _fork_state: ForkState<C, Q>,
     ) -> AnyResult<Response<C>> {
         let msg = from_json(msg)?;
         match &self.migrate_fn {
@@ -391,7 +391,7 @@ pub mod test {
     }
 
     fn query(deps: Deps, env: Env, _msg: Empty) -> StdResult<Binary> {
-        Ok(to_json_binary("resp")?)
+        to_json_binary("resp")
     }
 
     fn instantiate(deps: DepsMut, env: Env, info: MessageInfo, _msg: Empty) -> StdResult<Response> {

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -14,7 +14,7 @@ use cosmwasm_std::{
 use anyhow::Result as AnyResult;
 use serde::de::DeserializeOwned;
 
-use crate::wasm_emulation::{channel::RemoteChannel, query::mock_querier::ForkState};
+use crate::wasm_emulation::query::mock_querier::ForkState;
 use anyhow::{anyhow, bail};
 /// Interface to call into a [Contract].
 pub trait Contract<T, Q = Empty>
@@ -304,7 +304,7 @@ where
         msg: Vec<u8>,
         _fork_state: ForkState<Q>,
     ) -> AnyResult<Response<C>> {
-        let msg: T1 = from_json(&msg)?;
+        let msg: T1 = from_json(msg)?;
         (self.execute_fn)(deps, env, info, msg).map_err(|err| anyhow!(err))
     }
 
@@ -316,7 +316,7 @@ where
         msg: Vec<u8>,
         _fork_state: ForkState<Q>,
     ) -> AnyResult<Response<C>> {
-        let msg: T2 = from_json(&msg)?;
+        let msg: T2 = from_json(msg)?;
         (self.instantiate_fn)(deps, env, info, msg).map_err(|err| anyhow!(err))
     }
 
@@ -327,7 +327,7 @@ where
         msg: Vec<u8>,
         _fork_state: ForkState<Q>,
     ) -> AnyResult<Binary> {
-        let msg: T3 = from_json(&msg)?;
+        let msg: T3 = from_json(msg)?;
         (self.query_fn)(deps, env, msg).map_err(|err| anyhow!(err))
     }
 
@@ -339,7 +339,7 @@ where
         msg: Vec<u8>,
         _fork_state: ForkState<Q>,
     ) -> AnyResult<Response<C>> {
-        let msg = from_json(&msg)?;
+        let msg = from_json(msg)?;
         match &self.sudo_fn {
             Some(sudo) => sudo(deps, env, msg).map_err(|err| anyhow!(err)),
             None => bail!("sudo not implemented for contract"),
@@ -368,7 +368,7 @@ where
         msg: Vec<u8>,
         _fork_state: ForkState<Q>,
     ) -> AnyResult<Response<C>> {
-        let msg = from_json(&msg)?;
+        let msg = from_json(msg)?;
         match &self.migrate_fn {
             Some(migrate) => migrate(deps, env, msg).map_err(|err| anyhow!(err)),
             None => bail!("migrate not implemented for contract"),
@@ -378,7 +378,6 @@ where
 
 #[cfg(test)]
 pub mod test {
-    use std::error::Error;
 
     use cosmwasm_std::{
         testing::{mock_dependencies, mock_env, mock_info},

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -14,7 +14,13 @@ use cosmwasm_std::{
 use anyhow::Result as AnyResult;
 use serde::de::DeserializeOwned;
 
-use crate::wasm_emulation::query::mock_querier::ForkState;
+use crate::{
+    prefixed_storage::{PrefixedStorage, ReadonlyPrefixedStorage},
+    wasm_emulation::{
+        query::{mock_querier::ForkState, MockQuerier},
+        storage::dual_std_storage::DualStorage,
+    },
+};
 use anyhow::{anyhow, bail};
 /// Interface to call into a [Contract].
 pub trait Contract<T, Q = Empty>
@@ -302,8 +308,20 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        _fork_state: ForkState<C, Q>,
+        fork_state: ForkState<C, Q>,
     ) -> AnyResult<Response<C>> {
+        let querier = MockQuerier::new(fork_state.clone());
+        let mut storage = DualStorage::new(
+            fork_state.remote,
+            env.contract.address.to_string(),
+            Box::new(PrefixedStorage::new(deps.storage, &[])),
+        )?;
+        let deps = DepsMut {
+            storage: &mut storage,
+            api: deps.api,
+            querier: QuerierWrapper::new(&querier),
+        };
+
         let msg: T1 = from_json(msg)?;
         (self.execute_fn)(deps, env, info, msg).map_err(|err| anyhow!(err))
     }
@@ -314,8 +332,19 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        _fork_state: ForkState<C, Q>,
+        fork_state: ForkState<C, Q>,
     ) -> AnyResult<Response<C>> {
+        let querier = MockQuerier::new(fork_state.clone());
+        let mut storage = DualStorage::new(
+            fork_state.remote,
+            env.contract.address.to_string(),
+            Box::new(PrefixedStorage::new(deps.storage, &[])),
+        )?;
+        let deps = DepsMut {
+            storage: &mut storage,
+            api: deps.api,
+            querier: QuerierWrapper::new(&querier),
+        };
         let msg: T2 = from_json(msg)?;
         (self.instantiate_fn)(deps, env, info, msg).map_err(|err| anyhow!(err))
     }
@@ -325,8 +354,19 @@ where
         deps: Deps<Q>,
         env: Env,
         msg: Vec<u8>,
-        _fork_state: ForkState<C, Q>,
+        fork_state: ForkState<C, Q>,
     ) -> AnyResult<Binary> {
+        let querier = MockQuerier::new(fork_state.clone());
+        let mut storage = DualStorage::new(
+            fork_state.remote,
+            env.contract.address.to_string(),
+            Box::new(ReadonlyPrefixedStorage::new(deps.storage, &[])),
+        )?;
+        let deps = Deps {
+            storage: &mut storage,
+            api: deps.api,
+            querier: QuerierWrapper::new(&querier),
+        };
         let msg: T3 = from_json(msg)?;
         (self.query_fn)(deps, env, msg).map_err(|err| anyhow!(err))
     }
@@ -337,8 +377,19 @@ where
         deps: DepsMut<Q>,
         env: Env,
         msg: Vec<u8>,
-        _fork_state: ForkState<C, Q>,
+        fork_state: ForkState<C, Q>,
     ) -> AnyResult<Response<C>> {
+        let querier = MockQuerier::new(fork_state.clone());
+        let mut storage = DualStorage::new(
+            fork_state.remote,
+            env.contract.address.to_string(),
+            Box::new(PrefixedStorage::new(deps.storage, &[])),
+        )?;
+        let deps = DepsMut {
+            storage: &mut storage,
+            api: deps.api,
+            querier: QuerierWrapper::new(&querier),
+        };
         let msg = from_json(msg)?;
         match &self.sudo_fn {
             Some(sudo) => sudo(deps, env, msg).map_err(|err| anyhow!(err)),
@@ -352,8 +403,19 @@ where
         deps: DepsMut<Q>,
         env: Env,
         reply_data: Reply,
-        _fork_state: ForkState<C, Q>,
+        fork_state: ForkState<C, Q>,
     ) -> AnyResult<Response<C>> {
+        let querier = MockQuerier::new(fork_state.clone());
+        let mut storage = DualStorage::new(
+            fork_state.remote,
+            env.contract.address.to_string(),
+            Box::new(PrefixedStorage::new(deps.storage, &[])),
+        )?;
+        let deps = DepsMut {
+            storage: &mut storage,
+            api: deps.api,
+            querier: QuerierWrapper::new(&querier),
+        };
         match &self.reply_fn {
             Some(reply) => reply(deps, env, reply_data).map_err(|err| anyhow!(err)),
             None => bail!("reply not implemented for contract"),
@@ -366,8 +428,19 @@ where
         deps: DepsMut<Q>,
         env: Env,
         msg: Vec<u8>,
-        _fork_state: ForkState<C, Q>,
+        fork_state: ForkState<C, Q>,
     ) -> AnyResult<Response<C>> {
+        let querier = MockQuerier::new(fork_state.clone());
+        let mut storage = DualStorage::new(
+            fork_state.remote,
+            env.contract.address.to_string(),
+            Box::new(PrefixedStorage::new(deps.storage, &[])),
+        )?;
+        let deps = DepsMut {
+            storage: &mut storage,
+            api: deps.api,
+            querier: QuerierWrapper::new(&querier),
+        };
         let msg = from_json(msg)?;
         match &self.migrate_fn {
             Some(migrate) => migrate(deps, env, msg).map_err(|err| anyhow!(err)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,4 +40,6 @@ pub use crate::module::{AcceptingModule, FailingModule, Module};
 pub use crate::staking::{
     Distribution, DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo,
 };
-pub use crate::wasm::{ContractData, Wasm, WasmKeeper, WasmSudo};
+pub use crate::wasm::{
+    ContractData, Wasm, WasmKeeper, WasmSudo, LOCAL_RUST_CODE_OFFSET, LOCAL_WASM_CODE_OFFSET,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub use crate::app::{custom_app, next_block, App, BasicApp, CosmosRouter, Router
 pub use crate::app_builder::{AppBuilder, BasicAppBuilder};
 pub use crate::bank::{Bank, BankKeeper, BankSudo};
 pub use crate::checksums::ChecksumGenerator;
-pub use crate::contracts::Contract;
+pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};
 pub use crate::gov::{Gov, GovAcceptingModule, GovFailingModule};
 pub use crate::ibc::{Ibc, IbcAcceptingModule, IbcFailingModule};
@@ -40,4 +40,4 @@ pub use crate::module::{AcceptingModule, FailingModule, Module};
 pub use crate::staking::{
     Distribution, DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo,
 };
-pub use crate::wasm::{ContractData, Wasm, WasmKeeper, WasmSudo, LOCAL_CODE_OFFSET};
+pub use crate::wasm::{ContractData, Wasm, WasmKeeper, WasmSudo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,4 +40,4 @@ pub use crate::module::{AcceptingModule, FailingModule, Module};
 pub use crate::staking::{
     Distribution, DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo,
 };
-pub use crate::wasm::{ContractData, RawQueryFunc, Wasm, WasmKeeper, WasmSudo};
+pub use crate::wasm::{ContractData, Wasm, WasmKeeper, WasmSudo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,4 +40,4 @@ pub use crate::module::{AcceptingModule, FailingModule, Module};
 pub use crate::staking::{
     Distribution, DistributionKeeper, StakeKeeper, Staking, StakingInfo, StakingSudo,
 };
-pub use crate::wasm::{ContractData, Wasm, WasmKeeper, WasmSudo};
+pub use crate::wasm::{ContractData, RawQueryFunc, Wasm, WasmKeeper, WasmSudo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,3 +43,5 @@ pub use crate::staking::{
 pub use crate::wasm::{
     ContractData, Wasm, WasmKeeper, WasmSudo, LOCAL_RUST_CODE_OFFSET, LOCAL_WASM_CODE_OFFSET,
 };
+
+pub use prefixed_storage::{PrefixedStorage, ReadonlyPrefixedStorage};

--- a/src/queries/bank.rs
+++ b/src/queries/bank.rs
@@ -1,15 +1,10 @@
 use std::str::FromStr;
 
 use anyhow::Result as AnyResult;
-use cosmwasm_std::{Addr, Coin, Order, Storage, Uint128};
+use cosmwasm_std::{Addr, Coin, Uint128};
 use cw_orch_daemon::queriers::DaemonQuerier;
 
-use crate::{
-    bank::{BALANCES, NAMESPACE_BANK},
-    prefixed_storage::prefixed_read,
-    wasm_emulation::{channel::RemoteChannel, input::BankStorage},
-    BankKeeper,
-};
+use crate::wasm_emulation::channel::RemoteChannel;
 
 pub struct BankRemoteQuerier;
 

--- a/src/queries/bank.rs
+++ b/src/queries/bank.rs
@@ -7,7 +7,7 @@ use cw_orch_daemon::queriers::DaemonQuerier;
 use crate::{
     bank::{BALANCES, NAMESPACE_BANK},
     prefixed_storage::prefixed_read,
-    wasm_emulation::{channel::RemoteChannel, input::BankStorage, query::AllQuerier},
+    wasm_emulation::{channel::RemoteChannel, input::BankStorage},
     BankKeeper,
 };
 
@@ -31,16 +31,5 @@ impl BankRemoteQuerier {
             })
             .unwrap();
         Ok(distant_amounts)
-    }
-}
-
-impl AllQuerier for BankKeeper {
-    type Output = BankStorage;
-    fn query_all(&self, storage: &dyn Storage) -> AnyResult<BankStorage> {
-        let bank_storage = prefixed_read(storage, NAMESPACE_BANK);
-        let balances: Result<Vec<_>, _> = BALANCES
-            .range(&bank_storage, None, None, Order::Ascending)
-            .collect();
-        Ok(BankStorage { storage: balances? })
     }
 }

--- a/src/queries/wasm.rs
+++ b/src/queries/wasm.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
 use anyhow::Result as AnyResult;
-use cosmwasm_std::{Addr, Binary, CodeInfoResponse, Order, Storage};
+use cosmwasm_std::{Addr, Binary, CodeInfoResponse, CustomQuery, Order, Storage};
 use cw_orch_daemon::queriers::{CosmWasm, DaemonQuerier};
 
 use crate::{
     prefixed_storage::prefixed_read,
     wasm::{ContractData, CONTRACTS, NAMESPACE_WASM},
-    wasm_emulation::{channel::RemoteChannel, input::WasmStorage, query::AllQuerier},
+    wasm_emulation::{channel::RemoteChannel, input::WasmStorage, query::AllWasmQuerier},
     WasmKeeper,
 };
 
@@ -60,8 +60,7 @@ impl WasmRemoteQuerier {
     }
 }
 
-impl<ExecC, QueryC> AllQuerier for WasmKeeper<ExecC, QueryC> {
-    type Output = WasmStorage;
+impl<ExecC, QueryC: CustomQuery> AllWasmQuerier for WasmKeeper<ExecC, QueryC> {
     fn query_all(&self, storage: &dyn Storage) -> AnyResult<WasmStorage> {
         let all_local_state: Vec<_> = storage.range(None, None, Order::Ascending).collect();
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -13,7 +13,6 @@ use crate::wasm_emulation::contract::WasmContract;
 use crate::wasm_emulation::input::QuerierStorage;
 use crate::wasm_emulation::query::mock_querier::{ForkState, LocalForkedState};
 use crate::wasm_emulation::query::AllWasmQuerier;
-use crate::wasm_emulation::storage::dual_std_storage::DualStorage;
 use cosmwasm_std::testing::mock_wasmd_attr;
 use cosmwasm_std::CustomMsg;
 use cosmwasm_std::{
@@ -401,14 +400,7 @@ where
         let namespace = self.contract_namespace(address);
         let storage = PrefixedStorage::multilevel(storage, &[NAMESPACE_WASM, &namespace]);
 
-        let dual_storage = DualStorage::new(
-            self.remote.clone().unwrap(),
-            address.to_string(),
-            Box::new(storage),
-        )
-        .unwrap();
-
-        Box::new(dual_storage)
+        Box::new(storage)
     }
 
     // fails RUNTIME if you try to write. please don't
@@ -421,15 +413,7 @@ where
         // then from wasm_storage -> the contracts subspace
         let namespace = self.contract_namespace(address);
         let storage = ReadonlyPrefixedStorage::multilevel(storage, &[NAMESPACE_WASM, &namespace]);
-
-        let dual_storage = DualStorage::new(
-            self.remote.clone().unwrap(),
-            address.to_string(),
-            Box::new(storage),
-        )
-        .unwrap();
-
-        Box::new(dual_storage)
+        Box::new(storage)
     }
 
     fn verify_attributes(attributes: &[Attribute]) -> AnyResult<()> {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -600,8 +600,6 @@ where
         sender: Addr,
         wasm_msg: WasmMsg,
     ) -> AnyResult<AppResponse> {
-        let querier_storage = router.get_querier_storage(storage)?;
-
         match wasm_msg {
             WasmMsg::Execute {
                 contract_addr,
@@ -622,6 +620,7 @@ where
 
                 // then call the contract
                 let info = MessageInfo { sender, funds };
+                let querier_storage = router.get_querier_storage(storage)?;
 
                 let res = self.call_execute(
                     api,
@@ -691,6 +690,7 @@ where
                 self.save_contract(storage, &contract_addr, &data)?;
 
                 // then call migrate
+                let querier_storage = router.get_querier_storage(storage)?;
                 let res = self.call_migrate(
                     contract_addr.clone(),
                     api,
@@ -1155,6 +1155,7 @@ where
         msg: Vec<u8>,
         querier_storage: QuerierStorage,
     ) -> AnyResult<Response<ExecC>> {
+        let querier_storage = router.get_querier_storage(storage)?;
         Self::verify_response(self.with_storage(
             api,
             storage,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1155,7 +1155,6 @@ where
         msg: Vec<u8>,
         querier_storage: QuerierStorage,
     ) -> AnyResult<Response<ExecC>> {
-        let querier_storage = router.get_querier_storage(storage)?;
         Self::verify_response(self.with_storage(
             api,
             storage,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -10,7 +10,9 @@ use crate::queries::wasm::WasmRemoteQuerier;
 use crate::transactions::transactional;
 use crate::wasm_emulation::channel::RemoteChannel;
 use crate::wasm_emulation::contract::WasmContract;
-use crate::wasm_emulation::query::AllQuerier;
+use crate::wasm_emulation::input::{BankStorage, QuerierStorage, WasmStorage};
+use crate::wasm_emulation::query::mock_querier::ForkState;
+use crate::wasm_emulation::query::AllWasmQuerier;
 use cosmwasm_std::testing::mock_wasmd_attr;
 use cosmwasm_std::CustomMsg;
 use cosmwasm_std::{
@@ -24,6 +26,7 @@ use prost::Message;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::fmt::Debug;
 
@@ -35,7 +38,8 @@ pub(crate) const CONTRACTS: Map<&Addr, ContractData> = Map::new("contracts");
 pub(crate) const NAMESPACE_WASM: &[u8] = b"wasm";
 /// See <https://github.com/chipshort/wasmd/blob/d0e3ed19f041e65f112d8e800416b3230d0005a2/x/wasm/types/events.go#L58>
 const CONTRACT_ATTR: &str = "_contract_address";
-pub const LOCAL_CODE_OFFSET: usize = 5_000_000;
+pub const LOCAL_WASM_CODE_OFFSET: usize = 5_000_000;
+pub const LOCAL_RUST_CODE_OFFSET: usize = 10_000_000;
 
 #[derive(Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct WasmSudo {
@@ -79,12 +83,13 @@ pub struct CodeData {
     pub code_base_id: usize,
 }
 
-pub trait Wasm<ExecC, QueryC>: AllQuerier {
+pub trait Wasm<ExecC, QueryC: CustomQuery>: AllWasmQuerier {
     /// Handles all WasmQuery requests
     fn query(
         &self,
         api: &dyn Api,
         storage: &dyn Storage,
+        router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
         querier: &dyn Querier,
         block: &BlockInfo,
         request: WasmQuery,
@@ -113,11 +118,14 @@ pub trait Wasm<ExecC, QueryC>: AllQuerier {
     ) -> AnyResult<AppResponse>;
 
     /// Stores the contract's code and returns an identifier of the stored contract's code.
-    fn store_code(&mut self, creator: Addr, code: WasmContract) -> u64;
+    fn store_code(
+        &mut self,
+        creator: Addr,
+        code: (Box<dyn Contract<ExecC, QueryC>>, RawQueryFunc<QueryC>),
+    ) -> u64;
 
-    /// Duplicates the contract's code with specified identifier
-    /// and returns an identifier of the copy of the contract's code.
-    fn duplicate_code(&mut self, code_id: u64) -> AnyResult<u64>;
+    /// Stores the contract's code and returns an identifier of the stored contract's code.
+    fn store_wasm_code(&mut self, creator: Addr, code: WasmContract) -> u64;
 
     /// Returns `ContractData` for the contract with specified address.
     fn contract_data(&self, storage: &dyn Storage, address: &Addr) -> AnyResult<ContractData>;
@@ -126,10 +134,18 @@ pub trait Wasm<ExecC, QueryC>: AllQuerier {
     fn dump_wasm_raw(&self, storage: &dyn Storage, address: &Addr) -> Vec<Record>;
 }
 
-// pub struct WasmKeeper<ExecC: 'static, QueryC: 'static> {
-pub struct WasmKeeper<ExecC, QueryC> {
+pub type RawQueryFunc<QueryC> = fn(Deps<QueryC>, Env, Vec<u8>) -> Result<Binary, anyhow::Error>;
+pub struct LocalRustContract<ExecC, QueryC: CustomQuery> {
+    pub contract: Box<dyn Contract<ExecC, QueryC>>,
+    pub query: RawQueryFunc<QueryC>,
+}
+
+pub struct WasmKeeper<ExecC: 'static, QueryC: CustomQuery + 'static> {
     /// Contract codes that stand for wasm code in real-life blockchain.
     pub code_base: HashMap<usize, WasmContract>,
+    /// Contract codes that stand for rust code living in the current instance
+    /// We also associate the queries to them to make sure we are able to use them with the vm instance
+    pub rust_codes: HashMap<usize, LocalRustContract<ExecC, QueryC>>,
     /// Code data with code base identifier and additional attributes.  
     pub code_data: HashMap<usize, CodeData>,
     /// Contract's address generator.
@@ -142,7 +158,7 @@ pub struct WasmKeeper<ExecC, QueryC> {
     _p: std::marker::PhantomData<(ExecC, QueryC)>,
 }
 
-impl<ExecC, QueryC> Default for WasmKeeper<ExecC, QueryC> {
+impl<ExecC, QueryC: CustomQuery> Default for WasmKeeper<ExecC, QueryC> {
     fn default() -> WasmKeeper<ExecC, QueryC> {
         Self {
             code_base: HashMap::new(),
@@ -151,6 +167,7 @@ impl<ExecC, QueryC> Default for WasmKeeper<ExecC, QueryC> {
             checksum_generator: Box::new(SimpleChecksumGenerator),
             _p: std::marker::PhantomData,
             remote: None,
+            rust_codes: HashMap::new(),
         }
     }
 }
@@ -164,6 +181,7 @@ where
         &self,
         api: &dyn Api,
         storage: &dyn Storage,
+        router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
         querier: &dyn Querier,
         block: &BlockInfo,
         request: WasmQuery,
@@ -171,7 +189,15 @@ where
         match request {
             WasmQuery::Smart { contract_addr, msg } => {
                 let addr = api.addr_validate(&contract_addr)?;
-                self.query_smart(addr, api, storage, querier, block, msg.into())
+                self.query_smart(
+                    addr,
+                    api,
+                    storage,
+                    querier,
+                    block,
+                    msg.into(),
+                    router.get_querier_storage(storage)?,
+                )
             }
             WasmQuery::Raw { contract_addr, key } => {
                 let addr = api.addr_validate(&contract_addr)?;
@@ -226,15 +252,26 @@ where
     ) -> AnyResult<AppResponse> {
         let custom_event = Event::new("sudo").add_attribute(CONTRACT_ATTR, &contract);
 
-        let res = self.call_sudo(contract.clone(), api, storage, router, block, msg.to_vec())?;
+        let querier_storage = router.get_querier_storage(storage)?;
+
+        let res = self.call_sudo(
+            contract.clone(),
+            api,
+            storage,
+            router,
+            block,
+            msg.to_vec(),
+            querier_storage,
+        )?;
         let (res, msgs) = self.build_app_response(&contract, custom_event, res);
+        let querier_storage = router.get_querier_storage(storage)?;
         self.process_response(api, router, storage, block, contract, res, msgs)
     }
 
     /// Stores the contract's code in the in-memory lookup table.
     /// Returns an identifier of the stored contract code.
-    fn store_code(&mut self, creator: Addr, code: WasmContract) -> u64 {
-        let code_id = self.code_base.len() + 1 + LOCAL_CODE_OFFSET;
+    fn store_wasm_code(&mut self, creator: Addr, code: WasmContract) -> u64 {
+        let code_id = self.code_base.len() + 1 + LOCAL_WASM_CODE_OFFSET;
         self.code_base.insert(code_id, code);
         let checksum = self.checksum_generator.checksum(&creator, code_id as u64);
         self.code_data.insert(
@@ -248,26 +285,31 @@ where
         code_id as u64
     }
 
-    /// Duplicates the contract's code with specified identifier.
-    /// Returns an identifier of the copy of the contract's code.
-    fn duplicate_code(&mut self, code_id: u64) -> AnyResult<u64> {
-        let code_data = self.code_data(code_id)?;
-        let code = self
-            .code_base
-            .get(&(code_id as usize))
-            .ok_or(Error::UnregisteredCodeId(code_id))?;
-        let code_id = self.code_base.len() + 1 + LOCAL_CODE_OFFSET;
+    /// Stores the contract's code in the in-memory lookup table.
+    /// Returns an identifier of the stored contract code.
+    fn store_code(
+        &mut self,
+        creator: Addr,
+        code: (Box<dyn Contract<ExecC, QueryC>>, RawQueryFunc<QueryC>),
+    ) -> u64 {
+        let code_id = self.rust_codes.len() + 1 + LOCAL_RUST_CODE_OFFSET;
+        self.rust_codes.insert(
+            code_id,
+            LocalRustContract {
+                contract: code.0,
+                query: code.1,
+            },
+        );
+        let checksum = self.checksum_generator.checksum(&creator, code_id as u64);
         self.code_data.insert(
             code_id,
             CodeData {
-                creator: code_data.creator.clone(),
-                checksum: code_data.checksum.clone(),
+                creator,
+                checksum,
                 code_base_id: code_id,
             },
         );
-        self.code_base.insert(code_id, code.clone());
-
-        Ok(code_id as u64)
+        code_id as u64
     }
 
     /// Returns `ContractData` for the contract with specified address.
@@ -287,19 +329,46 @@ where
     }
 }
 
+pub enum ContractBox<'a, ExecC, QueryC> {
+    Borrowed(Box<&'a dyn Contract<ExecC, QueryC>>),
+    Owned(Box<dyn Contract<ExecC, QueryC>>),
+}
+
 impl<ExecC, QueryC> WasmKeeper<ExecC, QueryC>
 where
     ExecC: CustomMsg + DeserializeOwned + 'static,
     QueryC: CustomQuery + DeserializeOwned + 'static,
 {
+    /// Only for Clone-testing
+    fn fork_state(&self, querier_storage: QuerierStorage) -> AnyResult<ForkState<QueryC>> {
+        Ok(ForkState {
+            remote: self.remote.clone().unwrap(),
+            local_state: self
+                .rust_codes
+                .iter()
+                .map(|(id, code)| (*id, code.query))
+                .collect(),
+            querier_storage,
+        })
+    }
+
     /// Returns a handler to code of the contract with specified code id.
-    pub fn contract_code(&self, code_id: u64) -> AnyResult<WasmContract> {
+    pub fn contract_code<'a, 'b>(
+        &'a self,
+        code_id: u64,
+    ) -> AnyResult<ContractBox<'a, ExecC, QueryC>>
+    where
+        'a: 'b,
+    {
         let code_data = self.code_data(code_id)?;
         let code = self.code_base.get(&code_data.code_base_id);
         if let Some(code) = code {
-            Ok(code.clone())
+            Ok(ContractBox::Borrowed(Box::new(code)))
+        } else if let Some(rust_code) = self.rust_codes.get(&code_data.code_base_id) {
+            Ok(ContractBox::Borrowed(Box::new(&*rust_code.contract)))
         } else {
-            Ok(WasmContract::new_distant_code_id(code_id))
+            let wasm_contract = WasmContract::new_distant_code_id(code_id);
+            Ok(ContractBox::Owned(Box::new(wasm_contract)))
         }
     }
 
@@ -444,6 +513,7 @@ where
         querier: &dyn Querier,
         block: &BlockInfo,
         msg: Vec<u8>,
+        querier_storage: QuerierStorage,
     ) -> AnyResult<Binary> {
         self.with_storage_readonly(
             api,
@@ -451,14 +521,13 @@ where
             querier,
             block,
             address,
-            |handler, deps, env| {
-                <WasmContract as Contract<ExecC, QueryC>>::query(
-                    &handler,
-                    deps,
-                    env,
-                    msg,
-                    self.remote.clone().unwrap(),
-                )
+            |handler, deps, env| match handler {
+                ContractBox::Borrowed(contract) => {
+                    contract.query(deps, env, msg, self.fork_state(querier_storage)?)
+                }
+                ContractBox::Owned(contract) => {
+                    contract.query(deps, env, msg, self.fork_state(querier_storage)?)
+                }
             },
         )
     }
@@ -533,6 +602,8 @@ where
         sender: Addr,
         wasm_msg: WasmMsg,
     ) -> AnyResult<AppResponse> {
+        let querier_storage = router.get_querier_storage(storage)?;
+
         match wasm_msg {
             WasmMsg::Execute {
                 contract_addr,
@@ -553,6 +624,7 @@ where
 
                 // then call the contract
                 let info = MessageInfo { sender, funds };
+
                 let res = self.call_execute(
                     api,
                     storage,
@@ -561,12 +633,14 @@ where
                     block,
                     info,
                     msg.to_vec(),
+                    querier_storage,
                 )?;
 
                 let custom_event =
                     Event::new("execute").add_attribute(CONTRACT_ATTR, &contract_addr);
 
                 let (res, msgs) = self.build_app_response(&contract_addr, custom_event, res);
+
                 let mut res =
                     self.process_response(api, router, storage, block, contract_addr, res, msgs)?;
                 res.data = execute_response(res.data);
@@ -691,6 +765,7 @@ where
 
         // then call the contract
         let info = MessageInfo { sender, funds };
+        let querier_storage = router.get_querier_storage(storage)?;
         let res = self.call_instantiate(
             contract_addr.clone(),
             api,
@@ -699,6 +774,7 @@ where
             block,
             info,
             msg.to_vec(),
+            querier_storage,
         )?;
 
         let custom_event = Event::new("instantiate")
@@ -706,6 +782,7 @@ where
             .add_attribute("code_id", code_id.to_string());
 
         let (res, msgs) = self.build_app_response(&contract_addr, custom_event, res);
+
         let mut res = self.process_response(
             api,
             router,
@@ -803,6 +880,8 @@ where
 
         let res = self.call_reply(contract.clone(), api, storage, router, block, reply)?;
         let (res, msgs) = self.build_app_response(&contract, custom_event, res);
+
+        let querier_storage = router.get_querier_storage(storage)?;
         self.process_response(api, router, storage, block, contract, res, msgs)
     }
 
@@ -939,6 +1018,7 @@ where
         block: &BlockInfo,
         info: MessageInfo,
         msg: Vec<u8>,
+        querier_storage: QuerierStorage,
     ) -> AnyResult<Response<ExecC>> {
         Self::verify_response(self.with_storage(
             api,
@@ -946,8 +1026,13 @@ where
             router,
             block,
             address,
-            |contract, deps, env| {
-                contract.execute(deps, env, info, msg, self.remote.clone().unwrap())
+            |contract, deps, env| match contract {
+                ContractBox::Borrowed(contract) => {
+                    contract.execute(deps, env, info, msg, self.fork_state(querier_storage)?)
+                }
+                ContractBox::Owned(contract) => {
+                    contract.execute(deps, env, info, msg, self.fork_state(querier_storage)?)
+                }
             },
         )?)
     }
@@ -961,6 +1046,7 @@ where
         block: &BlockInfo,
         info: MessageInfo,
         msg: Vec<u8>,
+        querier_storage: QuerierStorage,
     ) -> AnyResult<Response<ExecC>> {
         Self::verify_response(self.with_storage(
             api,
@@ -968,8 +1054,13 @@ where
             router,
             block,
             address,
-            |contract, deps, env| {
-                contract.instantiate(deps, env, info, msg, self.remote.clone().unwrap())
+            |contract, deps, env| match contract {
+                ContractBox::Borrowed(contract) => {
+                    contract.instantiate(deps, env, info, msg, self.fork_state(querier_storage)?)
+                }
+                ContractBox::Owned(contract) => {
+                    contract.instantiate(deps, env, info, msg, self.fork_state(querier_storage)?)
+                }
             },
         )?)
     }
@@ -983,13 +1074,21 @@ where
         block: &BlockInfo,
         reply: Reply,
     ) -> AnyResult<Response<ExecC>> {
+        let querier_storage = router.get_querier_storage(storage)?;
         Self::verify_response(self.with_storage(
             api,
             storage,
             router,
             block,
             address,
-            |contract, deps, env| contract.reply(deps, env, reply, self.remote.clone().unwrap()),
+            |contract, deps, env| match contract {
+                ContractBox::Borrowed(contract) => {
+                    contract.reply(deps, env, reply, self.fork_state(querier_storage)?)
+                }
+                ContractBox::Owned(contract) => {
+                    contract.reply(deps, env, reply, self.fork_state(querier_storage)?)
+                }
+            },
         )?)
     }
 
@@ -1001,6 +1100,7 @@ where
         router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
         block: &BlockInfo,
         msg: Vec<u8>,
+        querier_storage: QuerierStorage,
     ) -> AnyResult<Response<ExecC>> {
         Self::verify_response(self.with_storage(
             api,
@@ -1008,7 +1108,14 @@ where
             router,
             block,
             address,
-            |contract, deps, env| contract.sudo(deps, env, msg, self.remote.clone().unwrap()),
+            |contract, deps, env| match contract {
+                ContractBox::Borrowed(contract) => {
+                    contract.sudo(deps, env, msg, self.fork_state(querier_storage)?)
+                }
+                ContractBox::Owned(contract) => {
+                    contract.sudo(deps, env, msg, self.fork_state(querier_storage)?)
+                }
+            },
         )?)
     }
 
@@ -1027,7 +1134,14 @@ where
             router,
             block,
             address,
-            |contract, deps, env| contract.migrate(deps, env, msg, self.remote.clone().unwrap()),
+            |contract, deps, env| match contract {
+                ContractBox::Borrowed(contract) => {
+                    contract.migrate(deps, env, msg, self.fork_state(QuerierStorage::default())?)
+                }
+                ContractBox::Owned(contract) => {
+                    contract.migrate(deps, env, msg, self.fork_state(QuerierStorage::default())?)
+                }
+            },
         )?)
     }
 
@@ -1041,8 +1155,8 @@ where
         }
     }
 
-    fn with_storage_readonly<F, T>(
-        &self,
+    fn with_storage_readonly<'a, 'b, F, T>(
+        &'a self,
         api: &dyn Api,
         storage: &dyn Storage,
         querier: &dyn Querier,
@@ -1051,10 +1165,11 @@ where
         action: F,
     ) -> AnyResult<T>
     where
-        F: FnOnce(WasmContract, Deps<QueryC>, Env) -> AnyResult<T>,
+        F: FnOnce(ContractBox<'b, ExecC, QueryC>, Deps<QueryC>, Env) -> AnyResult<T>,
+        'a: 'b,
     {
         let contract = self.contract_data(storage, &address)?;
-        let handler = self.contract_code(contract.code_id)?;
+        let handler = self.contract_code::<'a, 'b>(contract.code_id)?;
         let storage = self.contract_storage_readonly(storage, &address);
         let env = self.get_env(address, block);
 
@@ -1066,8 +1181,8 @@ where
         action(handler, deps, env)
     }
 
-    fn with_storage<F, T>(
-        &self,
+    fn with_storage<'a, 'b, F, T>(
+        &'a self,
         api: &dyn Api,
         storage: &mut dyn Storage,
         router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
@@ -1076,7 +1191,8 @@ where
         action: F,
     ) -> AnyResult<T>
     where
-        F: FnOnce(WasmContract, DepsMut<QueryC>, Env) -> AnyResult<T>,
+        F: FnOnce(ContractBox<'b, ExecC, QueryC>, DepsMut<QueryC>, Env) -> AnyResult<T>,
+        'a: 'b,
         ExecC: DeserializeOwned,
     {
         let contract = self.contract_data(storage, &address)?;

--- a/src/wasm_emulation/contract.rs
+++ b/src/wasm_emulation/contract.rs
@@ -114,9 +114,9 @@ impl WasmContract {
         Self::DistantCodeId(DistantCodeId { code_id })
     }
 
-    pub fn get_code<QueryC: CustomQuery + DeserializeOwned>(
+    pub fn get_code<ExecC: CustomMsg + 'static, QueryC: CustomQuery + DeserializeOwned>(
         &self,
-        fork_state: ForkState<QueryC>,
+        fork_state: ForkState<ExecC, QueryC>,
     ) -> AnyResult<Vec<u8>> {
         match self {
             WasmContract::Local(LocalWasmContract { code, .. }) => Ok(code.clone()),
@@ -151,7 +151,7 @@ impl WasmContract {
     >(
         &self,
         args: InstanceArguments,
-        fork_state: ForkState<QueryC>,
+        fork_state: ForkState<ExecC, QueryC>,
     ) -> AnyResult<WasmRunnerOutput<ExecC>> {
         let InstanceArguments {
             function,
@@ -170,7 +170,7 @@ impl WasmContract {
                 address.to_string(),
                 Some(init_storage),
             )?,
-            querier: MockQuerier::<QueryC>::new(fork_state),
+            querier: MockQuerier::<ExecC, QueryC>::new(fork_state),
         };
         let options = InstanceOptions {
             gas_limit: DEFAULT_GAS_LIMIT,
@@ -229,7 +229,7 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        fork_state: ForkState<QueryC>,
+        fork_state: ForkState<ExecC, QueryC>,
     ) -> AnyResult<Response<ExecC>> {
         // We start by building the dependencies we will pass through the wasm executer
         let execute_args = InstanceArguments {
@@ -254,7 +254,7 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        fork_state: ForkState<QueryC>,
+        fork_state: ForkState<ExecC, QueryC>,
     ) -> AnyResult<Response<ExecC>> {
         // We start by building the dependencies we will pass through the wasm executer
         let instantiate_arguments = InstanceArguments {
@@ -278,7 +278,7 @@ where
         deps: Deps<QueryC>,
         env: Env,
         msg: Vec<u8>,
-        fork_state: ForkState<QueryC>,
+        fork_state: ForkState<ExecC, QueryC>,
     ) -> AnyResult<Binary> {
         // We start by building the dependencies we will pass through the wasm executer
         let query_arguments = InstanceArguments {
@@ -303,7 +303,7 @@ where
         deps: DepsMut<QueryC>,
         env: Env,
         msg: Vec<u8>,
-        fork_state: ForkState<QueryC>,
+        fork_state: ForkState<ExecC, QueryC>,
     ) -> AnyResult<Response<ExecC>> {
         let sudo_args = InstanceArguments {
             function: WasmFunction::Sudo(SudoArgs { env, msg }),
@@ -327,7 +327,7 @@ where
         deps: DepsMut<QueryC>,
         env: Env,
         reply: Reply,
-        fork_state: ForkState<QueryC>,
+        fork_state: ForkState<ExecC, QueryC>,
     ) -> AnyResult<Response<ExecC>> {
         let reply_args = InstanceArguments {
             function: WasmFunction::Reply(ReplyArgs { env, reply }),
@@ -351,7 +351,7 @@ where
         deps: DepsMut<QueryC>,
         env: Env,
         msg: Vec<u8>,
-        fork_state: ForkState<QueryC>,
+        fork_state: ForkState<ExecC, QueryC>,
     ) -> AnyResult<Response<ExecC>> {
         let migrate_args = InstanceArguments {
             function: WasmFunction::Migrate(MigrateArgs { env, msg }),

--- a/src/wasm_emulation/contract.rs
+++ b/src/wasm_emulation/contract.rs
@@ -205,7 +205,7 @@ impl WasmContract {
 
     pub fn after_execution_callback<ExecC>(&self, output: &WasmRunnerOutput<ExecC>) {
         // We log the gas used
-        print!("Gas used {:?} for ", output.gas_used);
+        log::debug!("Gas used {:?} for ", output.gas_used);
         match output.wasm {
             WasmOutput::Execute(_) => print!("execution"),
             WasmOutput::Query(_) => print!("query"),
@@ -214,7 +214,7 @@ impl WasmContract {
             WasmOutput::Sudo(_) => print!("sudo"),
             WasmOutput::Reply(_) => print!("reply"),
         }
-        println!(" on contract {:?}. ", self);
+        log::debug!(" on contract {:?}. ", self);
     }
 }
 

--- a/src/wasm_emulation/contract.rs
+++ b/src/wasm_emulation/contract.rs
@@ -205,16 +205,20 @@ impl WasmContract {
 
     pub fn after_execution_callback<ExecC>(&self, output: &WasmRunnerOutput<ExecC>) {
         // We log the gas used
-        log::debug!("Gas used {:?} for ", output.gas_used);
-        match output.wasm {
-            WasmOutput::Execute(_) => print!("execution"),
-            WasmOutput::Query(_) => print!("query"),
-            WasmOutput::Instantiate(_) => print!("instantiation"),
-            WasmOutput::Migrate(_) => print!("migration"),
-            WasmOutput::Sudo(_) => print!("sudo"),
-            WasmOutput::Reply(_) => print!("reply"),
-        }
-        log::debug!(" on contract {:?}. ", self);
+        let operation = match output.wasm {
+            WasmOutput::Execute(_) => "execution",
+            WasmOutput::Query(_) => "query",
+            WasmOutput::Instantiate(_) => "instantiation",
+            WasmOutput::Migrate(_) => "migration",
+            WasmOutput::Sudo(_) => "sudo",
+            WasmOutput::Reply(_) => "reply",
+        };
+        log::debug!(
+            "Gas used {:?} for {:} on contract {:?}",
+            output.gas_used,
+            operation,
+            self
+        );
     }
 }
 

--- a/src/wasm_emulation/contract.rs
+++ b/src/wasm_emulation/contract.rs
@@ -1,28 +1,17 @@
 use crate::wasm_emulation::api::RealApi;
-use crate::wasm_emulation::input::get_querier_storage;
 use crate::wasm_emulation::input::ReplyArgs;
 use crate::wasm_emulation::output::StorageChanges;
 use crate::wasm_emulation::query::MockQuerier;
 use crate::wasm_emulation::storage::DualStorage;
 use cosmwasm_std::CustomMsg;
 use cosmwasm_std::StdError;
-use cosmwasm_vm::call_execute;
-use cosmwasm_vm::call_instantiate;
-use cosmwasm_vm::call_migrate;
-use cosmwasm_vm::call_query;
-use cosmwasm_vm::call_reply;
-use cosmwasm_vm::call_sudo;
-use cosmwasm_vm::Backend;
-use cosmwasm_vm::BackendApi;
-use cosmwasm_vm::Checksum;
-use cosmwasm_vm::Instance;
-use cosmwasm_vm::InstanceOptions;
-use cosmwasm_vm::Querier;
-use cosmwasm_vm::Size;
+use cosmwasm_vm::{
+    call_execute, call_instantiate, call_migrate, call_query, call_reply, call_sudo, Backend,
+    BackendApi, Checksum, Instance, InstanceOptions, Querier, Size,
+};
 use cw_orch_daemon::queriers::CosmWasm;
 use cw_orch_daemon::queriers::DaemonQuerier;
 
-use cosmwasm_std::Empty;
 use cosmwasm_std::Order;
 use cosmwasm_std::Storage;
 
@@ -33,9 +22,8 @@ use serde::Serialize;
 use crate::wasm_emulation::input::InstanceArguments;
 use crate::wasm_emulation::output::WasmRunnerOutput;
 
-use std::collections::HashSet;
-
 use cosmwasm_vm::internals::check_wasm;
+use std::collections::HashSet;
 
 use crate::Contract;
 
@@ -43,7 +31,6 @@ use cosmwasm_std::{Binary, CustomQuery, Deps, DepsMut, Env, MessageInfo, Reply, 
 
 use anyhow::Result as AnyResult;
 
-use super::channel::RemoteChannel;
 use super::input::ExecuteArgs;
 use super::input::InstantiateArgs;
 use super::input::MigrateArgs;
@@ -51,6 +38,7 @@ use super::input::QueryArgs;
 use super::input::SudoArgs;
 use super::input::WasmFunction;
 use super::output::WasmOutput;
+use super::query::mock_querier::ForkState;
 
 fn apply_storage_changes<ExecC>(storage: &mut dyn Storage, output: &WasmRunnerOutput<ExecC>) {
     // We change all the values with the output
@@ -83,18 +71,18 @@ pub struct DistantCodeId {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-pub struct LocalContract {
+pub struct LocalWasmContract {
     pub code: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub enum WasmContract {
-    Local(LocalContract),
+    Local(LocalWasmContract),
     DistantContract(DistantContract),
     DistantCodeId(DistantCodeId),
 }
 
-impl std::fmt::Debug for LocalContract {
+impl std::fmt::Debug for LocalWasmContract {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
@@ -115,7 +103,7 @@ impl WasmContract {
             ]),
         )
         .unwrap();
-        Self::Local(LocalContract { code })
+        Self::Local(LocalWasmContract { code })
     }
 
     pub fn new_distant_contract(contract_addr: String) -> Self {
@@ -126,49 +114,63 @@ impl WasmContract {
         Self::DistantCodeId(DistantCodeId { code_id })
     }
 
-    pub fn get_code(&self, remote: RemoteChannel) -> AnyResult<Vec<u8>> {
+    pub fn get_code<QueryC: CustomQuery + DeserializeOwned>(
+        &self,
+        fork_state: ForkState<QueryC>,
+    ) -> AnyResult<Vec<u8>> {
         match self {
-            WasmContract::Local(LocalContract { code, .. }) => Ok(code.clone()),
+            WasmContract::Local(LocalWasmContract { code, .. }) => Ok(code.clone()),
             WasmContract::DistantContract(DistantContract { contract_addr }) => {
-                let wasm_querier = CosmWasm::new(remote.channel);
+                let wasm_querier = CosmWasm::new(fork_state.remote.channel);
 
-                let code_info = remote
+                let code_info = fork_state
+                    .remote
                     .rt
                     .block_on(wasm_querier.contract_info(contract_addr))?;
-                let code = remote
+                let code = fork_state
+                    .remote
                     .rt
                     .block_on(wasm_querier.code_data(code_info.code_id))?;
                 Ok(code)
             }
             WasmContract::DistantCodeId(DistantCodeId { code_id }) => {
-                let wasm_querier = CosmWasm::new(remote.channel);
+                let wasm_querier = CosmWasm::new(fork_state.remote.channel);
 
-                let code = remote.rt.block_on(wasm_querier.code_data(*code_id))?;
+                let code = fork_state
+                    .remote
+                    .rt
+                    .block_on(wasm_querier.code_data(*code_id))?;
                 Ok(code)
             }
         }
     }
 
-    pub fn run_contract<ExecC: CustomMsg + DeserializeOwned>(
+    pub fn run_contract<
+        QueryC: CustomQuery + DeserializeOwned + 'static,
+        ExecC: CustomMsg + DeserializeOwned,
+    >(
         &self,
         args: InstanceArguments,
-        remote: RemoteChannel,
+        fork_state: ForkState<QueryC>,
     ) -> AnyResult<WasmRunnerOutput<ExecC>> {
         let InstanceArguments {
             function,
             init_storage,
-            querier_storage,
         } = args;
         let address = function.get_address();
-        let code = self.get_code(remote.clone())?;
+        let code = self.get_code(fork_state.clone())?;
 
-        let api = RealApi::new(&remote.chain.bech32_prefix);
+        let api = RealApi::new(&fork_state.remote.chain.bech32_prefix);
 
         // We create the backend here from outside information;
         let backend = Backend {
             api,
-            storage: DualStorage::new(remote.clone(), address.to_string(), Some(init_storage))?,
-            querier: MockQuerier::<Empty>::new(remote, Some(querier_storage)),
+            storage: DualStorage::new(
+                fork_state.remote.clone(),
+                address.to_string(),
+                Some(init_storage),
+            )?,
+            querier: MockQuerier::<QueryC>::new(fork_state),
         };
         let options = InstanceOptions {
             gas_limit: DEFAULT_GAS_LIMIT,
@@ -219,7 +221,7 @@ impl WasmContract {
 impl<ExecC, QueryC> Contract<ExecC, QueryC> for WasmContract
 where
     ExecC: CustomMsg + DeserializeOwned,
-    QueryC: CustomQuery,
+    QueryC: CustomQuery + DeserializeOwned,
 {
     fn execute(
         &self,
@@ -227,16 +229,15 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        remote: RemoteChannel,
+        fork_state: ForkState<QueryC>,
     ) -> AnyResult<Response<ExecC>> {
         // We start by building the dependencies we will pass through the wasm executer
         let execute_args = InstanceArguments {
             function: WasmFunction::Execute(ExecuteArgs { env, info, msg }),
             init_storage: deps.storage.range(None, None, Order::Ascending).collect(),
-            querier_storage: get_querier_storage(&deps.querier)?,
         };
 
-        let decoded_result = self.run_contract(execute_args, remote)?;
+        let decoded_result = self.run_contract(execute_args, fork_state)?;
 
         apply_storage_changes(deps.storage, &decoded_result);
         self.after_execution_callback(&decoded_result);
@@ -253,16 +254,15 @@ where
         env: Env,
         info: MessageInfo,
         msg: Vec<u8>,
-        remote: RemoteChannel,
+        fork_state: ForkState<QueryC>,
     ) -> AnyResult<Response<ExecC>> {
         // We start by building the dependencies we will pass through the wasm executer
         let instantiate_arguments = InstanceArguments {
             function: WasmFunction::Instantiate(InstantiateArgs { env, info, msg }),
             init_storage: deps.storage.range(None, None, Order::Ascending).collect(),
-            querier_storage: get_querier_storage(&deps.querier)?,
         };
 
-        let decoded_result = self.run_contract(instantiate_arguments, remote)?;
+        let decoded_result = self.run_contract(instantiate_arguments, fork_state)?;
 
         apply_storage_changes(deps.storage, &decoded_result);
         self.after_execution_callback(&decoded_result);
@@ -278,16 +278,16 @@ where
         deps: Deps<QueryC>,
         env: Env,
         msg: Vec<u8>,
-        remote: RemoteChannel,
+        fork_state: ForkState<QueryC>,
     ) -> AnyResult<Binary> {
         // We start by building the dependencies we will pass through the wasm executer
         let query_arguments = InstanceArguments {
             function: WasmFunction::Query(QueryArgs { env, msg }),
             init_storage: deps.storage.range(None, None, Order::Ascending).collect(),
-            querier_storage: get_querier_storage(&deps.querier)?,
         };
 
-        let decoded_result: WasmRunnerOutput<Empty> = self.run_contract(query_arguments, remote)?;
+        let decoded_result: WasmRunnerOutput<ExecC> =
+            self.run_contract(query_arguments, fork_state)?;
 
         self.after_execution_callback(&decoded_result);
 
@@ -303,15 +303,14 @@ where
         deps: DepsMut<QueryC>,
         env: Env,
         msg: Vec<u8>,
-        remote: RemoteChannel,
+        fork_state: ForkState<QueryC>,
     ) -> AnyResult<Response<ExecC>> {
         let sudo_args = InstanceArguments {
             function: WasmFunction::Sudo(SudoArgs { env, msg }),
             init_storage: deps.storage.range(None, None, Order::Ascending).collect(),
-            querier_storage: get_querier_storage(&deps.querier)?,
         };
 
-        let decoded_result = self.run_contract(sudo_args, remote)?;
+        let decoded_result = self.run_contract(sudo_args, fork_state)?;
 
         apply_storage_changes(deps.storage, &decoded_result);
         self.after_execution_callback(&decoded_result);
@@ -328,15 +327,14 @@ where
         deps: DepsMut<QueryC>,
         env: Env,
         reply: Reply,
-        remote: RemoteChannel,
+        fork_state: ForkState<QueryC>,
     ) -> AnyResult<Response<ExecC>> {
         let reply_args = InstanceArguments {
             function: WasmFunction::Reply(ReplyArgs { env, reply }),
             init_storage: deps.storage.range(None, None, Order::Ascending).collect(),
-            querier_storage: get_querier_storage(&deps.querier)?,
         };
 
-        let decoded_result = self.run_contract(reply_args, remote)?;
+        let decoded_result = self.run_contract(reply_args, fork_state)?;
 
         apply_storage_changes(deps.storage, &decoded_result);
         self.after_execution_callback(&decoded_result);
@@ -353,15 +351,14 @@ where
         deps: DepsMut<QueryC>,
         env: Env,
         msg: Vec<u8>,
-        remote: RemoteChannel,
+        fork_state: ForkState<QueryC>,
     ) -> AnyResult<Response<ExecC>> {
         let migrate_args = InstanceArguments {
             function: WasmFunction::Migrate(MigrateArgs { env, msg }),
             init_storage: deps.storage.range(None, None, Order::Ascending).collect(),
-            querier_storage: get_querier_storage(&deps.querier)?,
         };
 
-        let decoded_result = self.run_contract(migrate_args, remote)?;
+        let decoded_result = self.run_contract(migrate_args, fork_state)?;
 
         apply_storage_changes(deps.storage, &decoded_result);
         self.after_execution_callback(&decoded_result);

--- a/src/wasm_emulation/input.rs
+++ b/src/wasm_emulation/input.rs
@@ -1,25 +1,16 @@
 use std::collections::HashMap;
 
-use anyhow::Result as AnyResult;
-use serde::{Deserialize, Serialize};
-
 use cosmwasm_std::Addr;
-use cosmwasm_std::Binary;
-use cosmwasm_std::CustomQuery;
-use cosmwasm_std::QuerierWrapper;
-use cosmwasm_std::QueryRequest;
 use cosmwasm_std::{Env, MessageInfo, Reply};
 
 use cw_utils::NativeBalance;
 
-use crate::bank::BankKeeper;
 use crate::prefixed_storage::get_full_contract_storage_namespace;
 use crate::wasm::{CodeData, ContractData};
 
 use super::contract::WasmContract;
-use super::query::AllQuerier;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct WasmStorage {
     pub contracts: HashMap<String, ContractData>,
     pub codes: HashMap<usize, WasmContract>,
@@ -46,43 +37,24 @@ impl WasmStorage {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct BankStorage {
     pub storage: Vec<(Addr, NativeBalance)>,
 }
 
-#[derive(Serialize, Clone, Deserialize, Default, Debug)]
+#[derive(Clone, Default)]
 pub struct QuerierStorage {
     pub wasm: WasmStorage,
-    pub bank: <BankKeeper as AllQuerier>::Output,
+    pub bank: BankStorage,
 }
 
-pub const STARGATE_ALL_WASM_QUERY_URL: &str = "/local.wasm.all";
-pub const STARGATE_ALL_BANK_QUERY_URL: &str = "/local.bank.all";
-
-pub fn get_querier_storage<QueryC: CustomQuery>(
-    q: &QuerierWrapper<QueryC>,
-) -> AnyResult<QuerierStorage> {
-    // We get the wasm storage for all wasm contract to make sure we dispatch everything (with the mock Querier)
-    let wasm = q.query(&QueryRequest::Stargate {
-        path: STARGATE_ALL_WASM_QUERY_URL.to_string(),
-        data: Binary(vec![]),
-    })?;
-    let bank = q.query(&QueryRequest::Stargate {
-        path: STARGATE_ALL_BANK_QUERY_URL.to_string(),
-        data: Binary(vec![]),
-    })?;
-    Ok(QuerierStorage { wasm, bank })
-}
-
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
 pub struct InstanceArguments {
     pub function: WasmFunction,
     pub init_storage: Vec<(Vec<u8>, Vec<u8>)>,
-    pub querier_storage: QuerierStorage,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
 pub enum WasmFunction {
     Execute(ExecuteArgs),
     Instantiate(InstantiateArgs),
@@ -92,39 +64,39 @@ pub enum WasmFunction {
     Migrate(MigrateArgs),
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
 pub struct ExecuteArgs {
     pub env: Env,
     pub info: MessageInfo,
     pub msg: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
 pub struct InstantiateArgs {
     pub env: Env,
     pub info: MessageInfo,
     pub msg: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
 pub struct QueryArgs {
     pub env: Env,
     pub msg: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
 pub struct SudoArgs {
     pub env: Env,
     pub msg: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
 pub struct ReplyArgs {
     pub env: Env,
     pub reply: Reply,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
 pub struct MigrateArgs {
     pub env: Env,
     pub msg: Vec<u8>,

--- a/src/wasm_emulation/query/bank.rs
+++ b/src/wasm_emulation/query/bank.rs
@@ -31,9 +31,8 @@ pub struct BankQuerier {
 }
 
 impl BankQuerier {
-    pub fn new(remote: RemoteChannel, init: Option<Vec<(Addr, NativeBalance)>>) -> Self {
+    pub fn new(remote: RemoteChannel, init: Vec<(Addr, NativeBalance)>) -> Self {
         let balances: HashMap<_, _> = init
-            .unwrap_or(vec![])
             .iter()
             .map(|(s, c)| (s.to_string(), c.clone().into_vec()))
             .collect();

--- a/src/wasm_emulation/query/gas.rs
+++ b/src/wasm_emulation/query/gas.rs
@@ -19,3 +19,6 @@ pub const GAS_COST_QUERY_ERROR: u64 = 1000;
 // API (from cosmwasm_vm directly)
 pub const GAS_COST_HUMANIZE: u64 = 44;
 pub const GAS_COST_CANONICALIZE: u64 = 55;
+
+// All queries (test)
+pub const GAS_COST_ALL_QUERIES: u64 = 10_000;

--- a/src/wasm_emulation/query/mock_querier.rs
+++ b/src/wasm_emulation/query/mock_querier.rs
@@ -6,6 +6,7 @@ use crate::wasm_emulation::query::staking::StakingQuerier;
 use crate::wasm_emulation::query::wasm::WasmQuerier;
 
 use cosmwasm_std::CustomMsg;
+use cosmwasm_std::Env;
 use cosmwasm_vm::BackendResult;
 use cosmwasm_vm::GasInfo;
 
@@ -30,6 +31,12 @@ use crate::Contract;
 use super::gas::GAS_COST_QUERY_ERROR;
 
 #[derive(Clone)]
+pub struct LocalForkedState<ExecC, QueryC> {
+    pub contracts: HashMap<usize, *mut dyn Contract<ExecC, QueryC>>,
+    pub env: Env,
+}
+
+#[derive(Clone)]
 pub struct ForkState<ExecC, QueryC>
 where
     QueryC: CustomQuery + DeserializeOwned + 'static,
@@ -37,7 +44,7 @@ where
 {
     pub remote: RemoteChannel,
     /// Only query function right now, but we might pass along the whole application state to avoid stargate queries
-    pub local_state: HashMap<usize, *mut dyn Contract<ExecC, QueryC>>,
+    pub local_state: LocalForkedState<ExecC, QueryC>,
     pub querier_storage: QuerierStorage,
 }
 

--- a/src/wasm_emulation/query/mod.rs
+++ b/src/wasm_emulation/query/mod.rs
@@ -3,15 +3,18 @@ pub mod mock_querier;
 pub mod staking;
 pub mod wasm;
 use cosmwasm_std::Storage;
-use serde::de::DeserializeOwned;
 
 pub use mock_querier::MockQuerier;
 pub mod gas;
 
 use anyhow::Result as AnyResult;
-use serde::Serialize;
 
-pub trait AllQuerier {
-    type Output: Serialize + Clone + DeserializeOwned + Default;
-    fn query_all(&self, storage: &dyn Storage) -> AnyResult<Self::Output>;
+use super::input::{BankStorage, WasmStorage};
+
+pub trait AllWasmQuerier {
+    fn query_all(&self, storage: &dyn Storage) -> AnyResult<WasmStorage>;
+}
+
+pub trait AllBankQuerier {
+    fn query_all(&self, storage: &dyn Storage) -> AnyResult<BankStorage>;
 }

--- a/src/wasm_emulation/query/wasm.rs
+++ b/src/wasm_emulation/query/wasm.rs
@@ -11,7 +11,7 @@ use crate::wasm_emulation::query::MockQuerier;
 use crate::Contract;
 
 use crate::wasm_emulation::contract::WasmContract;
-use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
+use cosmwasm_std::testing::MockStorage;
 use cosmwasm_vm::GasInfo;
 
 use cosmwasm_std::{
@@ -74,7 +74,7 @@ impl<
                     get_full_contract_storage_namespace(&Addr::unchecked(contract_addr)).to_vec();
                 total_key.extend_from_slice(key);
 
-                let value: Vec<u8> = if let Some(value) = self
+                if let Some(value) = self
                     .fork_state
                     .querier_storage
                     .wasm
@@ -82,12 +82,12 @@ impl<
                     .iter()
                     .find(|e| e.0 == total_key)
                 {
-                    return (
+                    (
                         SystemResult::Ok(ContractResult::Ok(value.1.clone().into())),
                         GasInfo::with_externally_used(GAS_COST_RAW_COSMWASM_QUERY),
-                    );
+                    )
                 } else {
-                    return (
+                    (
                         SystemResult::Ok(
                             WasmRemoteQuerier::raw_query(
                                 remote,
@@ -98,8 +98,8 @@ impl<
                             .into(),
                         ),
                         GasInfo::with_externally_used(GAS_COST_RAW_COSMWASM_QUERY),
-                    );
-                };
+                    )
+                }
             }
             WasmQuery::Smart { contract_addr, msg } => {
                 let addr = Addr::unchecked(contract_addr);

--- a/src/wasm_emulation/query/wasm.rs
+++ b/src/wasm_emulation/query/wasm.rs
@@ -102,7 +102,6 @@ impl<
             }
             WasmQuery::Smart { contract_addr, msg } => {
                 let addr = Addr::unchecked(contract_addr);
-                println!("Trying to query {:?}", contract_addr);
 
                 let mut storage = MockStorage::default();
                 // Set the storage

--- a/src/wasm_emulation/query/wasm.rs
+++ b/src/wasm_emulation/query/wasm.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use crate::addons::MockApiBech32;
 use crate::prefixed_storage::get_full_contract_storage_namespace;
 use crate::queries::wasm::WasmRemoteQuerier;
 use crate::wasm_emulation::query::gas::{
@@ -116,7 +117,7 @@ impl<
 
                 let deps = OwnedDeps {
                     storage,
-                    api: MockApi::default(),
+                    api: MockApiBech32::new(&self.fork_state.remote.chain.bech32_prefix),
                     querier: MockQuerier::new(self.fork_state.clone()),
                     custom_query_type: PhantomData::<QueryC>,
                 };

--- a/src/wasm_emulation/query/wasm.rs
+++ b/src/wasm_emulation/query/wasm.rs
@@ -113,7 +113,7 @@ impl<
                     querier: MockQuerier::new(self.fork_state.clone()),
                     custom_query_type: PhantomData::<QueryC>,
                 };
-                let env = mock_env();
+                let env = self.fork_state.local_state.env.clone();
 
                 let result = if let Some(local_contract) = self
                     .fork_state
@@ -141,6 +141,7 @@ impl<
                     } else if let Some(local_contract) = self
                         .fork_state
                         .local_state
+                        .contracts
                         .get(&(local_contract.code_id as usize))
                     {
                         // Local Rust Contract case

--- a/src/wasm_emulation/query/wasm.rs
+++ b/src/wasm_emulation/query/wasm.rs
@@ -81,16 +81,24 @@ impl<
                     .iter()
                     .find(|e| e.0 == total_key)
                 {
-                    value.1.clone()
+                    return (
+                        SystemResult::Ok(ContractResult::Ok(value.1.clone().into())),
+                        GasInfo::with_externally_used(GAS_COST_RAW_COSMWASM_QUERY),
+                    );
                 } else {
-                    WasmRemoteQuerier::raw_query(remote, contract_addr.clone(), key.clone())
-                        .unwrap()
+                    return (
+                        SystemResult::Ok(
+                            WasmRemoteQuerier::raw_query(
+                                remote,
+                                contract_addr.clone(),
+                                key.clone(),
+                            )
+                            .map(Into::into)
+                            .into(),
+                        ),
+                        GasInfo::with_externally_used(GAS_COST_RAW_COSMWASM_QUERY),
+                    );
                 };
-
-                (
-                    SystemResult::Ok(ContractResult::Ok(value.into())),
-                    GasInfo::with_externally_used(GAS_COST_RAW_COSMWASM_QUERY),
-                )
             }
             WasmQuery::Smart { contract_addr, msg } => {
                 let addr = Addr::unchecked(contract_addr);

--- a/src/wasm_emulation/query/wasm.rs
+++ b/src/wasm_emulation/query/wasm.rs
@@ -13,11 +13,11 @@ use crate::wasm_emulation::contract::WasmContract;
 use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
 use cosmwasm_vm::GasInfo;
 
-use cosmwasm_std::ContractResult;
 use cosmwasm_std::{
     to_json_binary, Addr, ContractInfoResponse, CustomMsg, CustomQuery, OwnedDeps, Storage,
     SystemError, SystemResult,
 };
+use cosmwasm_std::{ContractInfo, ContractResult};
 
 use cosmwasm_std::WasmQuery;
 use serde::de::DeserializeOwned;
@@ -113,7 +113,10 @@ impl<
                     querier: MockQuerier::new(self.fork_state.clone()),
                     custom_query_type: PhantomData::<QueryC>,
                 };
-                let env = self.fork_state.local_state.env.clone();
+                let mut env = self.fork_state.local_state.env.clone();
+                env.contract = ContractInfo {
+                    address: Addr::unchecked(contract_addr),
+                };
 
                 let result = if let Some(local_contract) = self
                     .fork_state

--- a/src/wasm_emulation/query/wasm.rs
+++ b/src/wasm_emulation/query/wasm.rs
@@ -193,7 +193,8 @@ impl<
             #[cfg(feature = "cosmwasm_1_2")]
             WasmQuery::CodeInfo { code_id } => {
                 let code_data = self
-                    .current_storage
+                    .fork_state
+                    .querier_storage
                     .wasm
                     .code_data
                     .get(&(*code_id as usize));
@@ -204,7 +205,7 @@ impl<
                     res.checksum = code_data.checksum.clone();
                     res
                 } else {
-                    WasmRemoteQuerier::code_info(self.remote.clone(), *code_id).unwrap()
+                    WasmRemoteQuerier::code_info(self.fork_state.remote.clone(), *code_id).unwrap()
                 };
                 (
                     SystemResult::Ok(to_json_binary(&res).into()),

--- a/src/wasm_emulation/storage/analyzer.rs
+++ b/src/wasm_emulation/storage/analyzer.rs
@@ -2,8 +2,6 @@ use crate::prefixed_storage::decode_length;
 use crate::prefixed_storage::to_length_prefixed;
 use crate::prefixed_storage::CONTRACT_STORAGE_PREFIX;
 use crate::wasm_emulation::channel::RemoteChannel;
-use crate::wasm_emulation::input::BankStorage;
-use crate::wasm_emulation::input::WasmStorage;
 use crate::BankKeeper;
 use crate::Distribution;
 use crate::Gov;

--- a/src/wasm_emulation/storage/analyzer.rs
+++ b/src/wasm_emulation/storage/analyzer.rs
@@ -2,24 +2,25 @@ use crate::prefixed_storage::decode_length;
 use crate::prefixed_storage::to_length_prefixed;
 use crate::prefixed_storage::CONTRACT_STORAGE_PREFIX;
 use crate::wasm_emulation::channel::RemoteChannel;
-use crate::wasm_emulation::input::get_querier_storage;
-use crate::Bank;
+use crate::wasm_emulation::input::BankStorage;
+use crate::wasm_emulation::input::WasmStorage;
+use crate::BankKeeper;
 use crate::Distribution;
 use crate::Gov;
 use crate::Ibc;
 use crate::Module;
 use crate::Staking;
-use crate::Wasm;
+use crate::WasmKeeper;
 use cosmwasm_std::Addr;
 use cosmwasm_std::Api;
 use cosmwasm_std::Coin;
+use cosmwasm_std::CustomMsg;
 use cosmwasm_std::CustomQuery;
 use cosmwasm_std::Storage;
 use cw_orch_daemon::queriers::CosmWasm;
 use cw_orch_daemon::queriers::DaemonQuerier;
 use cw_utils::NativeBalance;
 use rustc_serialize::json::Json;
-use schemars::JsonSchema;
 use serde::Serialize;
 use serde::__private::from_utf8_lossy;
 use serde::de::DeserializeOwned;
@@ -44,15 +45,23 @@ pub struct StorageAnalyzer {
 }
 
 impl StorageAnalyzer {
-    pub fn new<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>(
-        app: &App<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT, IbcT, GovT>,
+    pub fn new<ApiT, StorageT, CustomT, StakingT, DistrT, IbcT, GovT>(
+        app: &App<
+            BankKeeper,
+            ApiT,
+            StorageT,
+            CustomT,
+            WasmKeeper<CustomT::ExecT, CustomT::QueryT>,
+            StakingT,
+            DistrT,
+            IbcT,
+            GovT,
+        >,
     ) -> AnyResult<Self>
     where
-        CustomT::ExecT:
-            std::fmt::Debug + PartialEq + Clone + JsonSchema + DeserializeOwned + 'static,
+        CustomT::ExecT: CustomMsg + DeserializeOwned + 'static,
         CustomT::QueryT: CustomQuery + DeserializeOwned + 'static,
-        WasmT: Wasm<CustomT::ExecT, CustomT::QueryT>,
-        BankT: Bank,
+
         ApiT: Api,
         StorageT: Storage,
         CustomT: Module,
@@ -62,7 +71,7 @@ impl StorageAnalyzer {
         GovT: Gov,
     {
         Ok(Self {
-            storage: get_querier_storage(&app.wrap())?,
+            storage: app.get_querier_storage()?,
             remote: app.remote.clone(),
         })
     }

--- a/src/wasm_emulation/storage/dual_std_storage.rs
+++ b/src/wasm_emulation/storage/dual_std_storage.rs
@@ -194,9 +194,9 @@ impl<'a> Storage for DualStorage<'a> {
         let descending_order: i32 = Order::Descending.try_into().unwrap();
 
         let querier_start = if order_i32 == descending_order {
-            end.map(|s| s.to_vec()).unwrap_or(vec![])
+            end.map(|s| s.to_vec()).unwrap_or_default()
         } else {
-            start.map(|s| s.to_vec()).unwrap_or(vec![])
+            start.map(|s| s.to_vec()).unwrap_or_default()
         };
 
         return Box::new(Iter {

--- a/src/wasm_emulation/storage/dual_std_storage.rs
+++ b/src/wasm_emulation/storage/dual_std_storage.rs
@@ -63,6 +63,8 @@ impl<'i> Iterator for Iter<'i> {
         // 1. We verify that there is enough elements in the distant iterator
         if self.distant_iter.position == self.distant_iter.data.len()
             && self.distant_iter.key.is_some()
+            && (self.distant_iter.position == 0
+                || !self.distant_iter.key.clone().unwrap().is_empty())
         {
             let wasm_querier = CosmWasm::new(self.distant_iter.remote.channel.clone());
             let new_keys = self

--- a/src/wasm_emulation/storage/dual_std_storage.rs
+++ b/src/wasm_emulation/storage/dual_std_storage.rs
@@ -1,0 +1,126 @@
+use crate::prefixed_storage::PrefixedStorage;
+use crate::wasm_emulation::channel::RemoteChannel;
+use crate::wasm_emulation::storage::mock_storage::{GAS_COST_LAST_ITERATION, GAS_COST_RANGE};
+
+use super::mock_storage::MockStorage;
+use cosmrs::proto::cosmos::base::query::v1beta1::PageRequest;
+use cosmrs::proto::cosmwasm::wasm::v1::Model;
+use cosmwasm_std::Record;
+use cosmwasm_std::{Order, Storage};
+use cw_orch_daemon::queriers::DaemonQuerier;
+use num_bigint::{BigInt, Sign};
+use std::collections::HashMap;
+use std::iter;
+
+use cw_orch_daemon::queriers::CosmWasm;
+
+fn get_key_bigint(mut key1: Vec<u8>, mut key2: Vec<u8>) -> (BigInt, BigInt) {
+    if key1.len() >= key2.len() {
+        key2.extend(iter::repeat(0).take(key1.len() - key2.len()))
+    } else {
+        key1.extend(iter::repeat(0).take(key2.len() - key1.len()))
+    }
+
+    (
+        BigInt::from_bytes_be(Sign::Plus, &key1),
+        BigInt::from_bytes_be(Sign::Plus, &key2),
+    )
+}
+
+fn gte(key1: Vec<u8>, key2: Vec<u8>) -> bool {
+    let ints = get_key_bigint(key1, key2);
+
+    ints.0 >= ints.1
+}
+
+fn _gt(key1: Vec<u8>, key2: Vec<u8>) -> bool {
+    let ints = get_key_bigint(key1, key2);
+    ints.0 > ints.1
+}
+
+use std::collections::HashSet;
+
+use anyhow::Result as AnyResult;
+const DISTANT_LIMIT: u64 = 5u64;
+
+#[derive(Default, Debug)]
+struct DistantIter {
+    data: Vec<Model>,
+    position: usize,
+    key: Option<Vec<u8>>, // if set to None, there is no more keys to investigate in the distant container
+    start: Option<Vec<u8>>,
+    end: Option<Vec<u8>>,
+    reverse: bool,
+}
+
+/// Iterator to get multiple keys
+#[derive(Default, Debug)]
+struct Iter {
+    distant_iter: DistantIter,
+    local_iter: u32,
+}
+
+pub struct DualStorage<'a> {
+    pub local_storage: Box<dyn Storage + 'a>,
+    pub removed_keys: HashSet<Vec<u8>>,
+    pub remote: RemoteChannel,
+    pub contract_addr: String,
+    iterators: HashMap<u32, Iter>,
+}
+
+impl<'a> DualStorage<'a> {
+    pub fn new(
+        remote: RemoteChannel,
+        contract_addr: String,
+        local_storage: Box<dyn Storage + 'a>,
+    ) -> AnyResult<DualStorage> {
+        Ok(Self {
+            local_storage,
+            remote,
+            removed_keys: HashSet::default(),
+            contract_addr,
+            iterators: HashMap::new(),
+        })
+    }
+}
+
+impl<'a> Storage for DualStorage<'a> {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        // First we try to get the value locally
+        let mut value = self.local_storage.get(key);
+        // If it's not available, we query it online if it was not removed locally
+        if !self.removed_keys.contains(key) && value.as_ref().is_none() {
+            let wasm_querier = CosmWasm::new(self.remote.channel.clone());
+
+            let distant_result = self.remote.rt.block_on(
+                wasm_querier.contract_raw_state(self.contract_addr.clone(), key.to_vec()),
+            );
+
+            if let Ok(result) = distant_result {
+                if !result.data.is_empty() {
+                    value = Some(result.data)
+                }
+            }
+        }
+        value
+    }
+
+    fn set(&mut self, key: &[u8], value: &[u8]) {
+        self.removed_keys.remove(key); // It's not locally removed anymore, because we set it locally
+        self.local_storage.set(key, value)
+    }
+
+    fn remove(&mut self, key: &[u8]) {
+        self.removed_keys.insert(key.to_vec()); // We indicate locally if it's removed. So that we can remove keys and not query them on the distant chain
+        self.local_storage.remove(key)
+    }
+
+    fn range<'b>(
+        &'b self,
+        start: Option<&[u8]>,
+        end: Option<&[u8]>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = Record> + 'b> {
+        todo!()
+    }
+}

--- a/src/wasm_emulation/storage/dual_storage.rs
+++ b/src/wasm_emulation/storage/dual_storage.rs
@@ -168,7 +168,6 @@ impl Storage for DualStorage {
         let iterator = match self.iterators.get_mut(&iterator_id) {
             Some(i) => i,
             None => {
-                println!("End next premature");
                 return (
                     Err(BackendError::iterator_does_not_exist(iterator_id)),
                     GasInfo::free(),

--- a/src/wasm_emulation/storage/dual_storage.rs
+++ b/src/wasm_emulation/storage/dual_storage.rs
@@ -135,9 +135,9 @@ impl Storage for DualStorage {
         let descending_order: i32 = Order::Descending.try_into().unwrap();
 
         let querier_start = if order_i32 == descending_order {
-            end.map(|s| s.to_vec()).unwrap_or(vec![])
+            end.map(|s| s.to_vec()).unwrap_or_default()
         } else {
-            start.map(|s| s.to_vec()).unwrap_or(vec![])
+            start.map(|s| s.to_vec()).unwrap_or_default()
         };
 
         let iter = Iter {

--- a/src/wasm_emulation/storage/dual_storage.rs
+++ b/src/wasm_emulation/storage/dual_storage.rs
@@ -174,6 +174,7 @@ impl Storage for DualStorage {
                 )
             }
         };
+        // TODO, work with removed keys and don't take them
 
         // 1. We verify that there is enough elements in the distant iterator
         if iterator.distant_iter.position == iterator.distant_iter.data.len()

--- a/src/wasm_emulation/storage/dual_storage.rs
+++ b/src/wasm_emulation/storage/dual_storage.rs
@@ -227,21 +227,8 @@ impl Storage for DualStorage {
             .data
             .get(iterator.distant_iter.position);
 
-        // We select the distant storage only if the keys are valid (inside the start, end range)
-        let is_valid_distant_key = next_distant.is_some()
-            && (iterator.distant_iter.end.is_none() || // If there is end no bound 
-					iterator.distant_iter.reverse || // if the iterator is reversed, 
-					!gte(next_distant.unwrap().key.clone(), iterator.distant_iter.end.clone().unwrap()))
-            && (iterator.distant_iter.start.is_none()
-                || !iterator.distant_iter.reverse
-                || gte(
-                    next_distant.unwrap().key.clone(),
-                    iterator.distant_iter.start.clone().unwrap(),
-                ));
-
         let key_value = if let Some(local) = next_local {
-            if is_valid_distant_key {
-                let distant = next_distant.unwrap();
+            if let Some(distant) = next_distant {
                 // We compare the two keys with the order and return the higher key
                 let key_local = BigInt::from_bytes_be(Sign::Plus, &local.0);
                 let key_distant = BigInt::from_bytes_be(Sign::Plus, &distant.key);
@@ -254,8 +241,7 @@ impl Storage for DualStorage {
             } else {
                 self.local_storage.next(iterator.local_iter).0.unwrap()
             }
-        } else if is_valid_distant_key {
-            let distant = next_distant.unwrap();
+        } else if let Some(distant) = next_distant {
             iterator.distant_iter.position += 1;
             Some((distant.key.clone(), distant.value.clone()))
         } else {

--- a/src/wasm_emulation/storage/mock_storage.rs
+++ b/src/wasm_emulation/storage/mock_storage.rs
@@ -14,16 +14,16 @@ pub const GAS_COST_RANGE: u64 = 11;
 // We needed to add the peak function on the cosmwasm-vm code
 // This is used for making sure we have the right order between distant and local storage
 
-#[derive(Default, Debug)]
-struct Iter {
+#[derive(Default, Debug, Clone)]
+pub struct Iter {
     data: Vec<Record>,
     position: usize,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct MockStorage {
-    data: BTreeMap<Vec<u8>, Vec<u8>>,
-    iterators: HashMap<u32, Iter>,
+    pub data: BTreeMap<Vec<u8>, Vec<u8>>,
+    pub iterators: HashMap<u32, Iter>,
 }
 
 impl MockStorage {

--- a/src/wasm_emulation/storage/mod.rs
+++ b/src/wasm_emulation/storage/mod.rs
@@ -1,6 +1,7 @@
 pub mod dual_std_storage;
 pub mod dual_storage;
 pub mod mock_storage;
+pub mod storage_wrappers;
 pub use dual_storage::DualStorage;
 
 pub use mock_storage::MockStorage;

--- a/src/wasm_emulation/storage/mod.rs
+++ b/src/wasm_emulation/storage/mod.rs
@@ -1,3 +1,4 @@
+pub mod dual_std_storage;
 pub mod dual_storage;
 pub mod mock_storage;
 pub use dual_storage::DualStorage;

--- a/src/wasm_emulation/storage/storage_wrappers.rs
+++ b/src/wasm_emulation/storage/storage_wrappers.rs
@@ -1,0 +1,71 @@
+use cosmwasm_std::{Order, Record, Storage};
+
+pub struct StorageWrapper<'a> {
+    storage: &'a mut dyn Storage,
+}
+
+impl<'a> StorageWrapper<'a> {
+    pub fn new(storage: &'a mut dyn Storage) -> Self {
+        StorageWrapper { storage }
+    }
+}
+
+impl<'a> Storage for StorageWrapper<'a> {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        self.storage.get(key)
+    }
+
+    fn set(&mut self, key: &[u8], value: &[u8]) {
+        self.storage.set(key, value)
+    }
+
+    fn remove(&mut self, key: &[u8]) {
+        self.storage.remove(key)
+    }
+
+    /// range allows iteration over a set of keys, either forwards or backwards
+    /// uses standard rust range notation, and eg db.range(b"foo"..b"bar") also works reverse
+    fn range<'b>(
+        &'b self,
+        start: Option<&[u8]>,
+        end: Option<&[u8]>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = Record> + 'b> {
+        self.storage.range(start, end, order)
+    }
+}
+
+pub struct ReadonlyStorageWrapper<'a> {
+    storage: &'a dyn Storage,
+}
+
+impl<'a> ReadonlyStorageWrapper<'a> {
+    pub fn new(storage: &'a dyn Storage) -> Self {
+        ReadonlyStorageWrapper { storage }
+    }
+}
+
+impl<'a> Storage for ReadonlyStorageWrapper<'a> {
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        self.storage.get(key)
+    }
+
+    fn set(&mut self, _key: &[u8], _value: &[u8]) {
+        unimplemented!()
+    }
+
+    fn remove(&mut self, _key: &[u8]) {
+        unimplemented!()
+    }
+
+    /// range allows iteration over a set of keys, either forwards or backwards
+    /// uses standard rust range notation, and eg db.range(b"foo"..b"bar") also works reverse
+    fn range<'b>(
+        &'b self,
+        start: Option<&[u8]>,
+        end: Option<&[u8]>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = Record> + 'b> {
+        self.storage.range(start, end, order)
+    }
+}


### PR DESCRIPTION
This PR aims at allowing to use rust contracts (like ContractWrapper), to be used with this version of cw-multi-test.
This includes lifetime hells, for anyone interested :)

## Issue
We need to pass the contract query logic to the MockQuerier struct that is used inside the Wasm Execution library.

Because of constraints that are specific to this library (`wasmd`), the MockQuerier struct has to be `'static`